### PR TITLE
Rename ComputeApi to ServerApi

### DIFF
--- a/acceptance/02-list-servers.go
+++ b/acceptance/02-list-servers.go
@@ -30,7 +30,7 @@ func main() {
 		panic(err)
 	}
 
-	api, err := gophercloud.ComputeApi(acc, gophercloud.ApiCriteria{
+	api, err := gophercloud.ServersApi(acc, gophercloud.ApiCriteria{
 		Name:      "cloudServersOpenStack",
 		Region:    "DFW",
 		VersionId: "2",

--- a/context.go
+++ b/context.go
@@ -77,14 +77,14 @@ func (c *Context) ProviderByName(name string) (p Provider, err error) {
 	return Provider{}, ErrProvider
 }
 
-// Instantiates a Cloud Servers object for the provider given.
-func (c *Context) ComputeApi(acc AccessProvider, criteria ApiCriteria) (ComputeProvider, error) {
+// Instantiates a Cloud Servers API for the provider given.
+func (c *Context) ServersApi(acc AccessProvider, criteria ApiCriteria) (CloudServersProvider, error) {
 	url := acc.FirstEndpointUrlByCriteria(criteria)
 	if url == "" {
 		return nil, ErrEndpoint
 	}
 
-	gcp := &genericCloudProvider{
+	gcp := &genericServersProvider{
 		endpoint: url,
 		context:  c,
 		access:   acc,

--- a/global_context.go
+++ b/global_context.go
@@ -43,6 +43,6 @@ func Authenticate(provider string, options AuthOptions) (*Access, error) {
 }
 
 // Instantiates a Cloud Servers object for the provider given.
-func ComputeApi(acc AccessProvider, criteria ApiCriteria) (ComputeProvider, error) {
-	return globalContext.ComputeApi(acc, criteria)
+func ServersApi(acc AccessProvider, criteria ApiCriteria) (CloudServersProvider, error) {
+	return globalContext.ServersApi(acc, criteria)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -15,8 +15,8 @@ type AccessProvider interface {
 	AuthToken() string
 }
 
-// ComputeProvider instances encapsulate a Cloud Servers API, should one exist in the service catalog
+// CloudServersProvider instances encapsulate a Cloud Servers API, should one exist in the service catalog
 // for your provider.
-type ComputeProvider interface {
+type CloudServersProvider interface {
 	ListServers() ([]Server, error)
 }

--- a/servers.go
+++ b/servers.go
@@ -7,9 +7,9 @@ import (
 	"github.com/racker/perigee"
 )
 
-// genericCloudProvider structures provide the implementation for generic OpenStack-compatible
-// ComputeProvider interfaces.
-type genericCloudProvider struct {
+// genericServersProvider structures provide the implementation for generic OpenStack-compatible
+// CloudServersProvider interfaces.
+type genericServersProvider struct {
 	// endpoint refers to the provider's API endpoint base URL.  This will be used to construct
 	// and issue queries.
 	endpoint string
@@ -22,8 +22,8 @@ type genericCloudProvider struct {
 	access AccessProvider
 }
 
-// See the ComputeProvider interface for details.
-func (gcp *genericCloudProvider) ListServers() ([]Server, error) {
+// See the CloudServersProvider interface for details.
+func (gcp *genericServersProvider) ListServers() ([]Server, error) {
 	var ss []Server
 
 	url := gcp.endpoint + "/servers"

--- a/servers_test.go
+++ b/servers_test.go
@@ -28,7 +28,7 @@ func TestGetServersApi(t *testing.T) {
 		internal: "http://localhost:8086",
 	}
 
-	_, err := c.ComputeApi(acc, ApiCriteria{
+	_, err := c.ServersApi(acc, ApiCriteria{
 		Name:      "cloudComputeOpenStack",
 		Region:    "dfw",
 		VersionId: "2",


### PR DESCRIPTION
ComputeApi never sat well with me.  OpenStack documents prefer to call
their computing service "Cloud Server" API instead.  So, I renamed all
public-facing types and procedure names to reflect this usage.

Fixes #33
