### PR TITLE
Add ListImages() support and acceptance test.

### DIFF
--- a/acceptance/05-list-images.go
+++ b/acceptance/05-list-images.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"flag"
+	"github.com/rackspace/gophercloud"
+)
+
+var quiet = flag.Bool("quiet", false, "Quiet mode for acceptance testing.  $? non-zero on error though.")
+var rgn = flag.String("r", "DFW", "Datacenter region to interrogate.")
+
+func main() {
+	provider, username, password := getCredentials()
+	flag.Parse()
+
+	auth, err := gophercloud.Authenticate(
+		provider,
+		gophercloud.AuthOptions{
+			Username: username,
+			Password: password,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	servers, err := gophercloud.ServersApi(auth, gophercloud.ApiCriteria{
+		Name:      "cloudServersOpenStack",
+		Region:    *rgn,
+		VersionId: "2",
+		UrlChoice: gophercloud.PublicURL,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	images, err := servers.ListImages()
+	if err != nil {
+		panic(err)
+	}
+
+	if !*quiet {
+		fmt.Println("ID,Name,MinRam,MinDisk")
+		for _, image := range images {
+			fmt.Printf("%s,\"%s\",%d,%d\n", image.Id, image.Name, image.MinRam, image.MinRam)
+		}
+	}
+}

--- a/images.go
+++ b/images.go
@@ -1,5 +1,23 @@
 package gophercloud
 
+import (
+	"github.com/racker/perigee"
+)
+
+// See the CloudImagesProvider interface for details.
+func (gsp *genericServersProvider) ListImages() ([]Image, error) {
+	var is []Image
+	url := gsp.endpoint + "/images"
+	err := perigee.Get(url, perigee.Options{
+		CustomClient: gsp.context.httpClient,
+		Results:      &struct{ Images *[]Image }{&is},
+		MoreHeaders: map[string]string{
+			"X-Auth-Token": gsp.access.AuthToken(),
+		},
+	})
+	return is, err
+}
+
 // ImageLink provides a reference to a image by either ID or by direct URL.
 // Some services use just the ID, others use just the URL.
 // This structure provides a common means of expressing both in a single field.
@@ -7,3 +25,50 @@ type ImageLink struct {
 	Id    string `json:"id"`
 	Links []Link `json:"links"`
 }
+
+// Image is used for JSON (un)marshalling.
+// It provides a description of an OS image.
+//
+// The Id field contains the image's unique identifier.
+// For example, this identifier will be useful for specifying which operating system to install on a new server instance.
+//
+// The MinDisk and MinRam fields specify the minimum resources a server must provide to be able to install the image.
+//
+// The Name field provides a human-readable moniker for the OS image.
+//
+// The Progress and Status fields indicate image-creation status.
+// Any usable image will have 100% progress.
+//
+// The Updated field indicates the last time this image was changed.
+//
+// OsDcfDiskConfig indicates the server's boot volume configuration.
+// Valid values are:
+//     AUTO
+//     ----
+//     The server is built with a single partition the size of the target flavor disk.
+//     The file system is automatically adjusted to fit the entire partition.
+//     This keeps things simple and automated.
+//     AUTO is valid only for images and servers with a single partition that use the EXT3 file system.
+//     This is the default setting for applicable Rackspace base images.
+//
+//     MANUAL
+//     ------
+//     The server is built using whatever partition scheme and file system is in the source image.
+//     If the target flavor disk is larger,
+//     the remaining disk space is left unpartitioned.
+//     This enables images to have non-EXT3 file systems, multiple partitions, and so on,
+//     and enables you to manage the disk configuration.
+//
+type Image struct {
+	Created         string `json:"created"`
+	Id              string `json:"id"`
+	Links           []Link `json:"links"`
+	MinDisk         int    `json:"minDisk"`
+	MinRam          int    `json:"minRam"`
+	Name            string `json:"name"`
+	Progress        int    `json:"progress"`
+	Status          string `json:"status"`
+	Updated         string `json:"updated"`
+	OsDcfDiskConfig string `json:"OS-DCF:diskConfig"`
+}
+

--- a/interfaces.go
+++ b/interfaces.go
@@ -18,6 +18,13 @@ type AccessProvider interface {
 // CloudServersProvider instances encapsulate a Cloud Servers API, should one exist in the service catalog
 // for your provider.
 type CloudServersProvider interface {
+  // Servers
+
 	ListServers() ([]Server, error)
 	ServerById(id string) (*Server, error)
+
+  // Images
+
+  ListImages() ([]Image, error)
 }
+


### PR DESCRIPTION
This is needed to support a (currently broken) acceptance test for
creating a cloud server.  Without the ability to auto-detect an image, a
human operator is required to specify an image manually, which defeats
the value of an automated test.
