### PR TITLE
Fix ListServers to yield full details.

### DIFF
--- a/acceptance/02-list-servers.go
+++ b/acceptance/02-list-servers.go
@@ -33,14 +33,47 @@ func main() {
 		panic(err)
 	}
 
+  tryFullDetails(api)
+  tryLinksOnly(api)
+}
+
+func tryLinksOnly(api gophercloud.CloudServersProvider) {
+	servers, err := api.ListServersLinksOnly()
+	if err != nil {
+		panic(err)
+	}
+
+	if !*quiet {
+    fmt.Println("Id,Name")
+		for _, s := range servers {
+      if s.AccessIPv4 != "" {
+        panic("IPv4 not expected")
+      }
+
+      if s.Status != "" {
+        panic("Status not expected")
+      }
+
+      if s.Progress != 0 {
+        panic("Progress not expected")
+      }
+
+			fmt.Printf("%s,\"%s\"\n", s.Id, s.Name)
+		}
+	}
+}
+
+func tryFullDetails(api gophercloud.CloudServersProvider) {
 	servers, err := api.ListServers()
 	if err != nil {
 		panic(err)
 	}
 
 	if !*quiet {
+    fmt.Println("Id,Name,AccessIPv4,Status,Progress")
 		for _, s := range servers {
-			fmt.Printf("%s\n", s.Id)
+			fmt.Printf("%s,\"%s\",%s,%s,%d\n", s.Id, s.Name, s.AccessIPv4, s.Status, s.Progress)
 		}
 	}
 }
+

--- a/interfaces.go
+++ b/interfaces.go
@@ -27,6 +27,7 @@ type CloudServersProvider interface {
   // Servers
 
 	ListServers() ([]Server, error)
+  ListServersLinksOnly() ([]Server, error)
 	ServerById(id string) (*Server, error)
 	CreateServer(ns NewServer) (*NewServer, error)
 	DeleteServerById(id string) error

--- a/servers.go
+++ b/servers.go
@@ -23,7 +23,7 @@ type genericServersProvider struct {
 }
 
 // See the CloudServersProvider interface for details.
-func (gcp *genericServersProvider) ListServers() ([]Server, error) {
+func (gcp *genericServersProvider) ListServersLinksOnly() ([]Server, error) {
 	var ss []Server
 
 	url := gcp.endpoint + "/servers"
@@ -33,6 +33,23 @@ func (gcp *genericServersProvider) ListServers() ([]Server, error) {
 		MoreHeaders: map[string]string{
 			"X-Auth-Token": gcp.access.AuthToken(),
 		},
+	})
+	return ss, err
+}
+
+// See the CloudServersProvider interface for details.
+func (gcp *genericServersProvider) ListServers() ([]Server, error) {
+	var ss []Server
+
+	err := gcp.context.WithReauth(gcp.access, func() error {
+		url := gcp.endpoint + "/servers/detail"
+		return perigee.Get(url, perigee.Options{
+			CustomClient: gcp.context.httpClient,
+			Results:      &struct{ Servers *[]Server }{&ss},
+			MoreHeaders: map[string]string{
+				"X-Auth-Token": gcp.access.AuthToken(),
+			},
+		})
 	})
 	return ss, err
 }


### PR DESCRIPTION
Also, provide ListServersLinksOnly() if you want to retain the older
behavior.  LinksOnly variant isn't terribly useful though, as it
provides virtually _no_ useful information other than the mere existence
of a server.

Fixes #45.
