### PR TITLE
Refactor common initialization sequences.

### DIFF
--- a/acceptance/libargs.go
+++ b/acceptance/libargs.go
@@ -128,3 +128,36 @@ func createServer(servers gophercloud.CloudServersProvider, imageRef, flavorRef,
 func findAlternativeFlavor() string {
 	return "3"  // 1GB image, up from 512MB image
 }
+
+// withIdentity authenticates the user against the provider's identity service, and provides an
+// accessor for additional services.
+func withIdentity(f func(gophercloud.AccessProvider)) {
+	provider, username, password := getCredentials()
+	acc, err := gophercloud.Authenticate(
+		provider,
+		gophercloud.AuthOptions{
+			Username: username,
+			Password: password,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	f(acc)
+}
+
+// withServerApi acquires the cloud servers API.
+func withServerApi(acc gophercloud.AccessProvider, f func(gophercloud.CloudServersProvider)) {
+	api, err := gophercloud.ServersApi(acc, gophercloud.ApiCriteria{
+		Name:      "cloudServersOpenStack",
+		Region:    "DFW",
+		VersionId: "2",
+		UrlChoice: gophercloud.PublicURL,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	f(api)
+}


### PR DESCRIPTION
I've been grossly violating the DRY principle for some time, in the name
of coding velocity.  After 9 or so acceptance tests, it's tiresome,
error-prone, and inconvenient to have to cut-and-paste the same
initialization code between modules.  The time is now to fix this,
before I write any more acceptance tests.  And, now that I have an
interface I'm happy with, writing future acceptance tests should go much
faster than even before.
