### PR TITLE
Create server to get details of if no other available.

### DIFF
--- a/acceptance/libargs.go
+++ b/acceptance/libargs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"crypto/rand"
 	"github.com/rackspace/gophercloud"
+	"time"
 )
 
 // getCredentials will verify existence of needed credential information
@@ -160,4 +161,21 @@ func withServerApi(acc gophercloud.AccessProvider, f func(gophercloud.CloudServe
 	}
 
 	f(api)
+}
+
+// waitForServerState polls, every 10 seconds, for a given server to appear in the indicated state.
+// This call will block forever if it never appears in the desired state, so if a timeout is required,
+// make sure to call this function in a goroutine.
+func waitForServerState(api gophercloud.CloudServersProvider, id, state string) error {
+	for {
+		s, err := api.ServerById(id)
+		if err != nil {
+			return err
+		}
+		if s.Status == state {
+			return nil
+		}
+		time.Sleep(10 * time.Second)
+	}
+	panic("Impossible")
 }


### PR DESCRIPTION
If you attempted to run 03-get-server-details.go on a cloud account
without a pre-existing cloud server, it would fail.  Clearly, this isn't
intended, as it doesn't exercise the get-server-details functionality.
I alter the code, as a last resort, create a new server.

We check first to see if a -i parameter has been set, and if so, we use
it directly.  Otherwise, we attempt to list servers available for the
user, and if at least one exists, we pick the first one we find.  Only
if those two conditions fail do we attempt to create a new server.
