### PR TITLE
Add update server capability.

### DIFF
--- a/acceptance/12-update-server.go
+++ b/acceptance/12-update-server.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"flag"
+	"github.com/rackspace/gophercloud"
+)
+
+var quiet = flag.Bool("quiet", false, "Quiet mode, for acceptance testing.  $? still indicates errors though.")
+
+func main() {
+	flag.Parse()
+	withIdentity(false, func(acc gophercloud.AccessProvider) {
+		withServerApi(acc, func(servers gophercloud.CloudServersProvider) {
+			log("Creating server")
+			id, err := createServer(servers, "", "", "", "")
+			if err != nil {
+				panic(err)
+			}
+			waitForServerState(servers, id, "ACTIVE")
+			defer servers.DeleteServerById(id)
+
+			log("Updating name of server")
+			newName := randomString("ACPTTEST", 32)
+			newDetails, err := servers.UpdateServer(id, gophercloud.NewServerSettings{
+				Name: newName,
+			})
+			if err != nil {
+				panic(err)
+			}
+			if newDetails.Name != newName {
+				panic("Name change didn't appear to take")
+			}
+
+			log("Done")
+		})
+	})
+}
+
+func log(s string) {
+	if !*quiet {
+		fmt.Println(s)
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -38,6 +38,7 @@ type CloudServersProvider interface {
 	RebootServer(id string, hard bool) error
 	RescueServer(id string) (string, error)
 	UnrescueServer(id string) error
+	UpdateServer(id string, newValues NewServerSettings) (*Server, error)
 
   // Images
 


### PR DESCRIPTION
This requires an updated version of Perigee, for it lacked a Put()
method.  Make sure you "go get -u github.com/racker/perigee" prior to
testing, or you'll get method not defined errors.
