### PR TITLE
Expose the service catalog

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -195,3 +195,8 @@ func (a *Access) Revoke(tok string) error {
 	})
 	return err
 }
+
+// See AccessProvider interface definition for details.
+func (a *Access) GetServiceCatalog() []CatalogEntry {
+	return a.ServiceCatalog
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -19,6 +19,9 @@ type AccessProvider interface {
 	// Reauthenticate attempts to acquire a new authentication token, if the feature is enabled by
 	// AuthOptions.AllowReauth.
 	Reauthenticate() error
+
+	// GetServiceCatalog returns the service catalog, an array of endpoints
+	GetServiceCatalog() []CatalogEntry
 }
 
 // CloudServersProvider instances encapsulate a Cloud Servers API, should one exist in the service catalog


### PR DESCRIPTION
It can be handy to see the whole service catalog, particularly when you don't find the endpoint you were expecting.

This is a more of a for-discussion pull request.  Things of which I am not sure:
- We could instead have one method, which takes a (possibly empty) ApiCriteria and returns all the matching endpoints.
- Should we wrap the ServiceCatalog in an interface?  I think Identity V3 breaks it, so we probably should.
- Is this an Openstack-API binding or a JClouds-style multi-API binding?  If the latter, then we definitely need an interface!
