### PR TITLE
Expose service catalog to interested parties.

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -195,3 +195,12 @@ func (a *Access) Revoke(tok string) error {
 	})
 	return err
 }
+
+// See ServiceCatalogerForIdentityV2 interface definition for details.
+// Note that the raw slice is returend; be careful not to alter the fields of any members,
+// for other components of Gophercloud may depend upon them.
+// If this becomes a problem in the future,
+// a future revision may return a deep-copy of the service catalog instead.
+func (a *Access) V2ServiceCatalog() []CatalogEntry {
+	return a.ServiceCatalog
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,6 +21,13 @@ type AccessProvider interface {
 	Reauthenticate() error
 }
 
+// ServiceCatalogerIdentityV2 interface provides direct access to the service catalog as offered by the Identity V2 API.
+// We regret we need to fracture the namespace of what should otherwise be a simple concept; however,
+// the OpenStack community saw fit to render V3's service catalog completely incompatible with V2.
+type ServiceCatalogerForIdentityV2 interface {
+	V2ServiceCatalog() []CatalogEntry
+}
+
 // CloudServersProvider instances encapsulate a Cloud Servers API, should one exist in the service catalog
 // for your provider.
 type CloudServersProvider interface {


### PR DESCRIPTION
Added ServiceCatalogerForIdentityV2 interface to allow interested
software access to the raw service catalog.  Note that the interface
supported must necessarily expose the specific version of Openstack
Identity API version, as V2 and V3 are completely incompatible with each
other.
