### PR TITLE
list objects in container

### DIFF
--- a/acceptance/33-list-objects.go
+++ b/acceptance/33-list-objects.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/rackspace/gophercloud"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var quiet = flag.Bool("quiet", false, "Quiet mode, for acceptance testing. $? still indicates errors though.")
+
+func main() {
+	withIdentity(false, func(auth gophercloud.AccessProvider) {
+		withObjectStoreApi(auth, func(osp gophercloud.ObjectStoreProvider) {
+			log("Generating random container name")
+			containerName := randomString("container-", 16)
+
+			log("Creating container " + containerName)
+			container, err := osp.CreateContainer(containerName)
+			if err != nil {
+				panic(err)
+			}
+
+			writer := container.BasicObjectUploader()
+			defer writer.Close()
+
+			// The number of objects to create in the container
+			numObjs := 3
+
+			for i := 0; i < numObjs; i++ {
+				reader := strings.NewReader(randomString("", 30))
+
+				_, err = io.Copy(writer, reader)
+				if err != nil {
+					panic(err)
+				}
+
+				err = writer.Commit(gophercloud.ObjectOpts{
+					Name:      "gophercloud-list-objects_test-object-" + strconv.Itoa(i) + ".txt",
+					Container: container,
+				})
+				if err != nil {
+					panic(err)
+				}
+			}
+
+			objects, err := container.ListObjects(gophercloud.OpenstackListOpts{
+				Full: false,
+			})
+			if err != nil {
+				panic(err)
+			}
+			log("Basic Object Info")
+			if !*quiet {
+				fmt.Printf("%+v\n", objects)
+			}
+
+			objects, err = container.ListObjects(gophercloud.OpenstackListOpts{
+				Full: true,
+			})
+			if err != nil {
+				panic(err)
+			}
+			log("Full Object Info")
+			if !*quiet {
+				fmt.Printf("%+v\n", objects)
+			}
+
+			for i := 0; i < numObjs; i++ {
+				log("Deleting object gophercloud-list-objects_test-object-" + strconv.Itoa(i) + ".txt")
+				err = container.DeleteObject("gophercloud-list-objects_test-object-" + strconv.Itoa(i) + ".txt")
+				if err != nil {
+					panic(err)
+				}
+			}
+
+			// Give the endpoint some time to fully delete all the objects in the container.
+			// Removing this pause can result in a 409 Error (Container not empty)
+			time.Sleep(1000 * time.Millisecond)
+
+			log("Deleting container " + containerName)
+			err = container.Delete()
+			if err != nil {
+				panic(err)
+			}
+
+			log("Done.")
+		})
+	})
+}
+
+func log(s ...interface{}) {
+	if !*quiet {
+		fmt.Println(s...)
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -64,6 +64,10 @@ type Container interface {
 
 	// DeleteObject removes an object from the container.
 	DeleteObject(name string) error
+
+	// ListObjects will return objects in the container. The listOpts parameter holds the
+	// options for retreiving the objects.
+	ListObjects(listOpts ListOptions) ([]ObjectInfo, error)
 }
 
 // ContainerInfo instances encapsulate information relating to a container. An object implementing the ContainerInfo
@@ -75,6 +79,38 @@ type ContainerInfo interface {
 	ObjCount() int
 	// Return the size of the container (in bytes)
 	Size() int
+}
+
+// ObjectInfo instances encapsulate information relating to a storage object. The methods associated
+// with an instance of ObjectInfo are for specifying fields that must be present in the implemented
+// structure
+type ObjectInfo interface {
+	// Return the name of the object.
+	GetName() string
+	// Return the object's hash.
+	GetHash() string
+	// Return the size of the object (in bytes).
+	GetSize() int
+	// Return the object's content-type.
+	GetContentType() string
+	// Return (as a string) the most recent date the object was modified.
+	GetLastModified() string
+}
+
+// ListOptions are options for any query that can be 'paged'.
+type ListOptions interface {
+	// Return the desired format. Setting Full to true will retrieve all the information available
+	// for the listed items, whereas false will only retrieve the item names.
+	GetFull() bool
+	// Return the limit. Limit is an integer parameter that represents the maximum number of items
+	// to return.
+	GetLimit() int
+	// Return the marker. Marker is a string parameter that tells the endpoint to return items whose name
+	// is greater in value than the specified marker.
+	GetMarker() string
+	// Return the end marker. EndMarker is a string parameter that tells the endpoint to return items
+	// whose name is lesser in value than the specified end marker.
+	GetEndMarker() string
 }
 
 // MetadataProvider grants access to custom metadata on some "thing", whatever that thing may be (e.g., containers,


### PR DESCRIPTION
This is my take on listing objects in a container (to close #126). A few notes on some of the choices I made:

1) I made an interface called ListOptions to be used for at least this (listing objects) and listing containers; Maybe other things, too. I think this is necessary since most providers will have different options available for listing items. I abstracted out a few parameters that should be available from all providers (specifically, limit, marker, end marker, and format) and used those parameters as the basis for the interface's methods.

2) I use reflection to extract the query parameters from the listOptions structure and create the query string. This seemed a bit unnatural, but I couldn't think of a better way to do it. On the bright side, I'd imagine that bit of code can be extended to cover all the data-types and then used by all providers to create query strings from structure parameters.

3) I chose to use the prefix 'Get' for the interface's methods. Though I acknowledge it isn't idiomatic Go, it was done purposefully to avoid name collisions. For example, a method called "Name()" would not work with OpenStack, since the endpoint's JSON response has a field called "Name".

Feedback encouraged.
