### PR TITLE
Add helper api builder for different openstack implementations

### DIFF
--- a/api_fetch.go
+++ b/api_fetch.go
@@ -1,0 +1,42 @@
+package gophercloud
+
+import(
+ "github.com/mitchellh/mapstructure"
+)
+
+//The default generic openstack api
+var OpenstackApi = map[string]interface{}{
+	"UrlChoice": PublicURL,
+}
+
+// Api for use with rackspace
+var RackspaceApi = map[string]interface{}{
+	"Name":      "cloudServersOpenStack",
+	"VersionId": "2",
+	"UrlChoice": PublicURL,
+}
+
+
+//Populates an ApiCriteria struct with the api values
+//from one of the api maps 
+func PopulateApi(variant string) (ApiCriteria, error){
+	var Api ApiCriteria
+	var variantMap map[string]interface{}
+
+	switch variant {
+	case "":
+		variantMap = OpenstackApi
+
+	case "openstack":
+		variantMap = OpenstackApi
+
+	case "rackspace": 
+		variantMap = RackspaceApi
+	}
+
+	err := mapstructure.Decode(variantMap,&Api)
+		if err != nil{
+			return Api,err
+		}
+	return Api, err 
+}


### PR DESCRIPTION
This adds support for easily extending ApiCriteria depending on the fields required for different OpenStack implementations.
