### PR TITLE
Prevent panic on incorrect auth

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -137,6 +137,7 @@ func getAuthCredentials(options AuthOptions) Auth {
 // I didn't need another one.
 func (c *Context) papersPlease(p Provider, options AuthOptions) (*Access, error) {
 	var access *Access
+	access = new(Access)
 
 	if (options.Username == "") || (options.Password == "" && options.ApiKey == "") {
 		return nil, ErrCredentials


### PR DESCRIPTION
In playing with packer recently, I was running into a `panic: runtime error: invalid memory address or nil pointer dereference`.  Looking over open issues, I found #162 which had a similar panic.

The result of my issue was that packer was reading in my environment vars (specifically OS_TENANT_NAME), which was causing an issue with authentication.  Removing this env var, allowed everything to work.

The cause was that `access` was never created, and the `access.options` assignment would fail as a result.

With the change in this pull request you instead get the following from packer (instead of a panic):

```
Build 'openstack' errored: Missing endpoint, or insufficient privileges to access endpoint
```

Unfortunately, I don't have a _great_ handle on gophercloud yet, and this change does break tests:

```
--- FAIL: TestAuthenticationNeverReauths (0.00 seconds)
    authenticate_test.go:249: Expected an error from a 401 Unauthorized response
FAIL
exit status 1
FAIL    github.com/rackspace/gophercloud    0.021s
```

Perhaps there is a better way to handle this.  If there is, feel free to close this and make the required changes.
