### PR TITLE
Inspect response Code on Authenticate 

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -1,6 +1,7 @@
 package gophercloud
 
 import (
+	"fmt"
 	"github.com/racker/perigee"
 )
 
@@ -108,6 +109,20 @@ type EntryEndpoint struct {
 	VersionId, VersionInfo, VersionList string
 }
 
+type AuthError struct {
+	StatusCode int
+}
+
+func (ae *AuthError) Error() string {
+	switch ae.StatusCode {
+	case 401:
+		return "Auth failed. Bad credentials."
+
+	default:
+		return fmt.Sprintf("Auth failed. Status code is: %s.", ae.StatusCode)
+	}
+}
+
 //
 func getAuthCredentials(options AuthOptions) Auth {
 	if options.ApiKey == "" {
@@ -143,7 +158,7 @@ func (c *Context) papersPlease(p Provider, options AuthOptions) (*Access, error)
 		return nil, ErrCredentials
 	}
 
-	err := perigee.Post(p.AuthEndpoint, perigee.Options{
+	resp, err := perigee.Request("POST", p.AuthEndpoint, perigee.Options{
 		CustomClient: c.httpClient,
 		ReqBody: &AuthContainer{
 			Auth: getAuthCredentials(options),
@@ -154,11 +169,21 @@ func (c *Context) papersPlease(p Provider, options AuthOptions) (*Access, error)
 			&access,
 		},
 	})
+
 	if err == nil {
-		access.options = options
-		access.provider = p
-		access.context = c
+		switch resp.StatusCode {
+		case 200:
+			access.options = options
+			access.provider = p
+			access.context = c
+
+		default:
+			err = &AuthError {
+				StatusCode: resp.StatusCode,
+			}
+		}
 	}
+
 	return access, err
 }
 

--- a/global_context.go
+++ b/global_context.go
@@ -57,9 +57,11 @@ func ServersApi(acc AccessProvider, criteria ApiCriteria) (CloudServersProvider,
 // ActualResponseCode inspects a returned error, and discovers the actual response actual
 // response code that caused the error to be raised.
 func ActualResponseCode(e error) (int, error) {
-	err, ok := e.(*perigee.UnexpectedResponseCodeError)
-	if !ok {
-		return 0, ErrError
+	if err, typeOk := e.(*perigee.UnexpectedResponseCodeError); typeOk {
+		return err.Actual, nil
+	} else if err, typeOk := e.(*AuthError); typeOk{
+		return err.StatusCode, nil
 	}
-	return err.Actual, nil
+
+	return 0, ErrError
 }


### PR DESCRIPTION
This PR uses the Request method instead of the Post method to allow for introspection into the status code returned by the auth API. This then enables correct handling of authentication failures and unexpected status code returns by a library user.
