### PR TITLE
Require HTTP 200 from os-keypairs in CreateKeyPair

### DIFF
--- a/keypairs.go
+++ b/keypairs.go
@@ -47,6 +47,7 @@ func (gsp *genericServersProvider) CreateKeyPair(nkp NewKeyPair) (KeyPair, error
 			MoreHeaders: map[string]string{
 				"X-Auth-Token": gsp.access.AuthToken(),
 			},
+			OkCodes: []int{200},
 		})
 	})
 	return kp, err


### PR DESCRIPTION
I was trying to use [Packer](https://github.com/mitchellh/packer) with a private OpenStack cloud (provided by [Metacloud](http://www.metacloud.com/)) and having a problem (https://github.com/mitchellh/packer/issues/480). By packet tracing with Wireshark, I discovered that there was an HTTP 404 error happening which was ignored.

```
POST /v1/a5920c8f7bf6441a9e2e96eb7b62d1d5/os-keypairs HTTP/1.1
Host: <redacted>:8776
User-Agent: Go 1.1 package http
Content-Length: 66
Accept: application/json
Content-Type: application/json
X-Auth-Token: ae48751056aa494e82ebcd0b3ca4f334
Accept-Encoding: gzip

{"keypair":{"name":"packer 53e95eff-84ef-dfe7-4e96-0ef468b95711"}}
```

```
HTTP/1.1 404 Not Found
Content-Length: 52
Content-Type: text/plain; charset=UTF-8
Date: Tue, 12 Aug 2014 00:25:34 GMT

404 Not Found

The resource could not be found.
```

The above 404 was not treated as a failure and things proceeded and failed on a later call. (interesting to note that the 404 is happening because it's trying to call a Nova function, `os-keypairs`, but it's hitting port 8776, which is the Volume service -- this could be a bug in endpoint discovery?)
**Edit: This is because of the issue in https://github.com/rackspace/gophercloud/pull/176**

I modified the `CreateKeyPair` function so that it reports an error if it doesn't get an HTTP 200 response.
