### PR TITLE
osutil.AuthOptions appends /tokens to provider

### DIFF
--- a/osutil/auth.go
+++ b/osutil/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/rackspace/gophercloud"
 	"os"
+	"strings"
 )
 
 var (
@@ -53,6 +54,10 @@ func AuthOptions() (string, gophercloud.AuthOptions, error) {
 		Password:   password,
 		TenantId:   tenantId,
 		TenantName: tenantName,
+	}
+
+	if !strings.HasSuffix(provider, "/tokens") {
+		provider += "/tokens"
 	}
 
 	return provider, ao, nil


### PR DESCRIPTION
if not already present.

A typical `OS_AUTH_URL` is:

``` bash
OS_AUTH_URL=http://<hostname>:5000/v2.0
```

We need to append `"/tokens"` to this in order for auth calls to work.

Sample program: https://gist.github.com/msabramo/e21a6d3a24c5aa3441c6

That program fails unless you add a line like:

``` go
provider += "/tokens"
```
