### PR TITLE
PopulateApi return an error for unknown variant

### DIFF
--- a/api_fetch.go
+++ b/api_fetch.go
@@ -1,6 +1,7 @@
 package gophercloud
 
 import(
+ "fmt"
  "github.com/mitchellh/mapstructure"
 )
 
@@ -33,6 +34,11 @@ func PopulateApi(variant string) (ApiCriteria, error){
 
 	case "rackspace": 
 		variantMap = RackspaceApi
+
+	default:
+		var err = fmt.Errorf(
+			"PopulateApi: Unknown variant %# v; legal values: \"openstack\", \"rackspace\"", variant)
+		return Api, err
 	}
 
 	err := mapstructure.Decode(variantMap,&Api)


### PR DESCRIPTION
Before this, you could pass any variant name you wanted and if it didn't match `"rackspace"` or `"openstack"`, then we'd return a blank `ApiCriteria`. This would cause code that's trying to talk to, say, Compute, to get the first service in the catalog, regardless of whether it's the one that they wanted (this is the problem that I alluded to in https://github.com/rackspace/gophercloud/pull/174 where I was using [Packer](https://github.com/mitchellh/packer) and it was querying for the **Compute** API, but I had an incorrect value specified for the `variant` (`"openstack_provider"` in the Packer template file) and this resulted in Packer getting the **Volume** API instead of the **Compute** API). Therefore, I say that it's safer to return an error for an unknown variant, because returning a blank `ApiCriteria` tends to cause problems that are confusing and hard-to-debug.

Cc: @jrperritt, @mitchellh
