### PR TITLE
Make "Missing endpoint..." error more informative

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package gophercloud
 import (
 	"net/http"
 	"strings"
+	"fmt"
 )
 
 // Provider structures exist for each tangible provider of OpenStack service.
@@ -110,7 +111,10 @@ func (c *Context) ProviderByName(name string) (p Provider, err error) {
 func (c *Context) ServersApi(acc AccessProvider, criteria ApiCriteria) (CloudServersProvider, error) {
 	url := acc.FirstEndpointUrlByCriteria(criteria)
 	if url == "" {
-		return nil, ErrEndpoint
+		var err = fmt.Errorf(
+			"Missing endpoint, or insufficient privileges to access endpoint; criteria = %# v",
+			criteria)
+		return nil, err
 	}
 
 	gcp := &genericServersProvider{

--- a/errors.go
+++ b/errors.go
@@ -26,11 +26,6 @@ var ErrCredentials = fmt.Errorf("Missing or incomplete credentials")
 // this error when attempting to register it against a context.
 var ErrConfiguration = fmt.Errorf("Missing or incomplete configuration")
 
-// ErrEndpoint errors happen when no endpoint with the desired characteristics
-// exists in the service catalog.  This can also happen if your tenant lacks
-// adequate permissions to access a given endpoint.
-var ErrEndpoint = fmt.Errorf("Missing endpoint, or insufficient privileges to access endpoint")
-
 // ErrError errors happen when you attempt to discover the response code
 // responsible for a previous request bombing with an error, but pass in an
 // error interface which doesn't belong to the web client.


### PR DESCRIPTION
Now it's "Missing endpoint, or insufficient privileges to access endpoint; criteria = %# v"

Having the `criteria` shown makes it clear why it's failing.

Take this example:

```
Missing endpoint, or insufficient privileges to access endpoint;
criteria = gophercloud.ApiCriteria{
Name:"nova", Type:"", Region:"RegionOne", VersionId:"", UrlChoice: 0, IgnoreEnvVars:false}
```

By looking at the value of `criteria`, we can see that it was asking for an API with the name `"nova"`. And apparently it didn't find one in the `ServiceCatalog`.
