### PR TITLE
Query for type "compute" instead of name "nova"

### DIFF
--- a/api_fetch.go
+++ b/api_fetch.go
@@ -7,7 +7,7 @@ import(
 
 //The default generic openstack api
 var OpenstackApi = map[string]interface{}{
-        "Name":      "nova",
+	"Type": "compute",
 	"UrlChoice": PublicURL,
 }
 


### PR DESCRIPTION
The former doesn't work in my private OpenStack cloud (from Metacloud), because the service is not named "nova"; it's named "Compute Service".

```
{
    Name:      "Compute Service",
    Type:      "compute",
    ...
}
```

As a result of this, I was getting this error from gophercloud while trying to run the Packer OpenStack builder:

```
Missing endpoint, or insufficient privileges to access endpoint
```

I think type "compute" is probably a more portable way to do it. That was the impression I got from looking at
http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/Service_Types-d1e265.html

Cc: @sam-falvo, @jrperritt, @mitchellh
