### PR TITLE
make object's 'Content' type more generic (from *bytes.Reader to io.Read...

### DIFF
--- a/openstack/storage/v1/objects/objects.go
+++ b/openstack/storage/v1/objects/objects.go
@@ -1,8 +1,8 @@
 package objects
 
 import (
-	"bytes"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"strings"
 )
@@ -29,7 +29,7 @@ type DownloadOpts struct {
 type CreateOpts struct {
 	Container string
 	Name      string
-	Content   *bytes.Buffer
+	Content   io.Reader
 	Metadata  map[string]string
 	Headers   map[string]string
 	Params    map[string]string

--- a/openstack/storage/v1/objects/requests.go
+++ b/openstack/storage/v1/objects/requests.go
@@ -85,7 +85,7 @@ func Create(c *storage.Client, opts CreateOpts) error {
 
 	content := opts.Content
 	if content != nil {
-		reqBody = make([]byte, content.Len())
+		reqBody = make([]byte, 0)
 		_, err = content.Read(reqBody)
 		if err != nil {
 			return err


### PR DESCRIPTION
...er)

I'm thinking that when creating an object with content, the content can be anything that's readable. One gotcha that would need to be documented would be that users passing in a ReadCloser would need to "Close" the "Reader" in their app code. Thoughts?
