### PR TITLE
Rename "Interface" to "Availability".

### DIFF
--- a/acceptance/openstack/identity/v3/endpoint_test.go
+++ b/acceptance/openstack/identity/v3/endpoint_test.go
@@ -29,7 +29,7 @@ func TestListEndpoints(t *testing.T) {
 		for _, endpoint := range endpoints3.AsEndpoints(page) {
 			t.Logf("Endpoint: %8s %10s %9s %s",
 				endpoint.ID,
-				endpoint.Interface,
+				endpoint.Availability,
 				endpoint.Name,
 				endpoint.URL)
 		}
@@ -66,8 +66,8 @@ func TestNavigateCatalog(t *testing.T) {
 
 	// Enumerate the endpoints available for this service.
 	endpointResults, err := endpoints3.List(client, endpoints3.ListOpts{
-		Interface: gophercloud.InterfacePublic,
-		ServiceID: computeService.ID,
+		Availability: gophercloud.AvailabilityPublic,
+		ServiceID:    computeService.ID,
 	})
 
 	allEndpoints, err := gophercloud.AllPages(endpointResults)

--- a/endpoint_search.go
+++ b/endpoint_search.go
@@ -10,18 +10,18 @@ var (
 	ErrEndpointNotFound = errors.New("No suitable endpoint could be found in the service catalog.")
 )
 
-// Interface describes the accessibility of a specific service endpoint.
-type Interface string
+// Availability describes the accessibility of a specific service endpoint.
+type Availability string
 
 const (
-	// InterfaceAdmin makes an endpoint only available to administrators.
-	InterfaceAdmin Interface = "admin"
+	// AvailabilityAdmin makes an endpoint only available to administrators.
+	AvailabilityAdmin Availability = "admin"
 
-	// InterfacePublic makes an endpoint available to everyone.
-	InterfacePublic Interface = "public"
+	// AvailabilityPublic makes an endpoint available to everyone.
+	AvailabilityPublic Availability = "public"
 
-	// InterfaceInternal makes an endpoint only available within the cluster.
-	InterfaceInternal Interface = "internal"
+	// AvailabilityInternal makes an endpoint only available within the cluster.
+	AvailabilityInternal Availability = "internal"
 )
 
 // EndpointOpts contains options for finding an endpoint for an Openstack client.
@@ -40,10 +40,10 @@ type EndpointOpts struct {
 	// Region must be specified for services that span multiple regions.
 	Region string
 
-	// Interface is the visibility of the endpoint to be returned: InterfacePublic, InterfaceInternal, or InterfaceAdmin
-	// Interface is not required, and defaults to InterfacePublic.
-	// Not all interface types are accepted by all providers or identity services.
-	Interface Interface
+	// Availability is the visibility of the endpoint to be returned: AvailabilityPublic, AvailabilityInternal, or AvailabilityAdmin.
+	// Availability is not required, and defaults to InterfacePublic.
+	// Not all providers or services offer all Availability options.
+	Availability Availability
 }
 
 // EndpointLocator is a function that describes how to locate a single endpoint from a service catalog for a specific ProviderClient.

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -153,13 +153,13 @@ func v2endpointLocator(authResults identity2.AuthResults, opts gophercloud.Endpo
 
 	// Extract the appropriate URL from the matching Endpoint.
 	for _, endpoint := range endpoints {
-		switch opts.Interface {
-		case gophercloud.InterfacePublic:
+		switch opts.Availability {
+		case gophercloud.AvailabilityPublic:
 			return endpoint.PublicURL, nil
-		case gophercloud.InterfaceInternal:
+		case gophercloud.AvailabilityInternal:
 			return endpoint.InternalURL, nil
 		default:
-			return "", fmt.Errorf("Unexpected interface in endpoint query: %s", opts.Interface)
+			return "", fmt.Errorf("Unexpected availability in endpoint query: %s", opts.Availability)
 		}
 	}
 
@@ -195,9 +195,9 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 }
 
 func v3endpointLocator(v3Client *gophercloud.ServiceClient, opts gophercloud.EndpointOpts) (string, error) {
-	// Default Interface to InterfacePublic, if it isn't provided.
-	if opts.Interface == "" {
-		opts.Interface = gophercloud.InterfacePublic
+	// Default Availability to InterfacePublic, if it isn't provided.
+	if opts.Availability == "" {
+		opts.Availability = gophercloud.AvailabilityPublic
 	}
 
 	// Discover the service we're interested in.
@@ -233,8 +233,8 @@ func v3endpointLocator(v3Client *gophercloud.ServiceClient, opts gophercloud.End
 
 	// Enumerate the endpoints available for this service.
 	endpointResults, err := endpoints3.List(v3Client, endpoints3.ListOpts{
-		Interface: opts.Interface,
-		ServiceID: service.ID,
+		Availability: opts.Availability,
+		ServiceID:    service.ID,
 	})
 	if err != nil {
 		return "", err

--- a/openstack/identity/v3/endpoints/errors.go
+++ b/openstack/identity/v3/endpoints/errors.go
@@ -7,8 +7,8 @@ func requiredAttribute(attribute string) error {
 }
 
 var (
-	// ErrInterfaceRequired is reported if an Endpoint is created without an Interface.
-	ErrInterfaceRequired = requiredAttribute("an interface")
+	// ErrAvailabilityRequired is reported if an Endpoint is created without an Availability.
+	ErrAvailabilityRequired = requiredAttribute("an availability")
 
 	// ErrNameRequired is reported if an Endpoint is created without a Name.
 	ErrNameRequired = requiredAttribute("a name")

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -18,11 +18,11 @@ func maybeString(original string) *string {
 
 // EndpointOpts contains the subset of Endpoint attributes that should be used to create or update an Endpoint.
 type EndpointOpts struct {
-	Interface gophercloud.Interface
-	Name      string
-	Region    string
-	URL       string
-	ServiceID string
+	Availability gophercloud.Availability
+	Name         string
+	Region       string
+	URL          string
+	ServiceID    string
 }
 
 // Create inserts a new Endpoint into the service catalog.
@@ -46,8 +46,8 @@ func Create(client *gophercloud.ServiceClient, opts EndpointOpts) (*Endpoint, er
 	}
 
 	// Ensure that EndpointOpts is fully populated.
-	if opts.Interface == "" {
-		return nil, ErrInterfaceRequired
+	if opts.Availability == "" {
+		return nil, ErrAvailabilityRequired
 	}
 	if opts.Name == "" {
 		return nil, ErrNameRequired
@@ -62,7 +62,7 @@ func Create(client *gophercloud.ServiceClient, opts EndpointOpts) (*Endpoint, er
 	// Populate the request body.
 	reqBody := request{
 		Endpoint: endpoint{
-			Interface: string(opts.Interface),
+			Interface: string(opts.Availability),
 			Name:      opts.Name,
 			URL:       opts.URL,
 			ServiceID: opts.ServiceID,
@@ -87,17 +87,17 @@ func Create(client *gophercloud.ServiceClient, opts EndpointOpts) (*Endpoint, er
 // ListOpts allows finer control over the the endpoints returned by a List call.
 // All fields are optional.
 type ListOpts struct {
-	Interface gophercloud.Interface
-	ServiceID string
-	Page      int
-	PerPage   int
+	Availability gophercloud.Availability
+	ServiceID    string
+	Page         int
+	PerPage      int
 }
 
 // List enumerates endpoints in a paginated collection, optionally filtered by ListOpts criteria.
 func List(client *gophercloud.ServiceClient, opts ListOpts) (*EndpointList, error) {
 	q := make(map[string]string)
-	if opts.Interface != "" {
-		q["interface"] = string(opts.Interface)
+	if opts.Availability != "" {
+		q["interface"] = string(opts.Availability)
 	}
 	if opts.ServiceID != "" {
 		q["service_id"] = opts.ServiceID
@@ -144,7 +144,7 @@ func Update(client *gophercloud.ServiceClient, endpointID string, opts EndpointO
 	}
 
 	reqBody := request{Endpoint: endpoint{}}
-	reqBody.Endpoint.Interface = maybeString(string(opts.Interface))
+	reqBody.Endpoint.Interface = maybeString(string(opts.Availability))
 	reqBody.Endpoint.Name = maybeString(opts.Name)
 	reqBody.Endpoint.Region = maybeString(opts.Region)
 	reqBody.Endpoint.URL = maybeString(opts.URL)

--- a/openstack/identity/v3/endpoints/requests_test.go
+++ b/openstack/identity/v3/endpoints/requests_test.go
@@ -59,23 +59,23 @@ func TestCreateSuccessful(t *testing.T) {
 	client := serviceClient()
 
 	result, err := Create(client, EndpointOpts{
-		Interface: gophercloud.InterfacePublic,
-		Name:      "the-endiest-of-points",
-		Region:    "underground",
-		URL:       "https://1.2.3.4:9000/",
-		ServiceID: "asdfasdfasdfasdf",
+		Availability: gophercloud.AvailabilityPublic,
+		Name:         "the-endiest-of-points",
+		Region:       "underground",
+		URL:          "https://1.2.3.4:9000/",
+		ServiceID:    "asdfasdfasdfasdf",
 	})
 	if err != nil {
 		t.Fatalf("Unable to create an endpoint: %v", err)
 	}
 
 	expected := &Endpoint{
-		ID:        "12",
-		Interface: gophercloud.InterfacePublic,
-		Name:      "the-endiest-of-points",
-		Region:    "underground",
-		ServiceID: "asdfasdfasdfasdf",
-		URL:       "https://1.2.3.4:9000/",
+		ID:           "12",
+		Availability: gophercloud.AvailabilityPublic,
+		Name:         "the-endiest-of-points",
+		Region:       "underground",
+		ServiceID:    "asdfasdfasdfasdf",
+		URL:          "https://1.2.3.4:9000/",
 	}
 
 	if !reflect.DeepEqual(result, expected) {
@@ -135,20 +135,20 @@ func TestListEndpoints(t *testing.T) {
 	expected := &EndpointList{
 		Endpoints: []Endpoint{
 			Endpoint{
-				ID:        "12",
-				Interface: gophercloud.InterfacePublic,
-				Name:      "the-endiest-of-points",
-				Region:    "underground",
-				ServiceID: "asdfasdfasdfasdf",
-				URL:       "https://1.2.3.4:9000/",
+				ID:           "12",
+				Availability: gophercloud.AvailabilityPublic,
+				Name:         "the-endiest-of-points",
+				Region:       "underground",
+				ServiceID:    "asdfasdfasdfasdf",
+				URL:          "https://1.2.3.4:9000/",
 			},
 			Endpoint{
-				ID:        "13",
-				Interface: gophercloud.InterfaceInternal,
-				Name:      "shhhh",
-				Region:    "underground",
-				ServiceID: "asdfasdfasdfasdf",
-				URL:       "https://1.2.3.4:9001/",
+				ID:           "13",
+				Availability: gophercloud.AvailabilityInternal,
+				Name:         "shhhh",
+				Region:       "underground",
+				ServiceID:    "asdfasdfasdfasdf",
+				URL:          "https://1.2.3.4:9001/",
 			},
 		},
 	}
@@ -201,12 +201,12 @@ func TestUpdateEndpoint(t *testing.T) {
 	}
 
 	expected := &Endpoint{
-		ID:        "12",
-		Interface: gophercloud.InterfacePublic,
-		Name:      "renamed",
-		Region:    "somewhere-else",
-		ServiceID: "asdfasdfasdfasdf",
-		URL:       "https://1.2.3.4:9000/",
+		ID:           "12",
+		Availability: gophercloud.AvailabilityPublic,
+		Name:         "renamed",
+		Region:       "somewhere-else",
+		ServiceID:    "asdfasdfasdfasdf",
+		URL:          "https://1.2.3.4:9000/",
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, was %#v", expected, actual)

--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -9,12 +9,12 @@ import (
 
 // Endpoint describes the entry point for another service's API.
 type Endpoint struct {
-	ID        string                `json:"id"`
-	Interface gophercloud.Interface `json:"interface"`
-	Name      string                `json:"name"`
-	Region    string                `json:"region"`
-	ServiceID string                `json:"service_id"`
-	URL       string                `json:"url"`
+	ID           string                   `json:"id"`
+	Availability gophercloud.Availability `json:"interface"`
+	Name         string                   `json:"name"`
+	Region       string                   `json:"region"`
+	ServiceID    string                   `json:"service_id"`
+	URL          string                   `json:"url"`
 }
 
 // EndpointList contains a page of Endpoint results.


### PR DESCRIPTION
Interface is what the identity v3 docs call it, but that collides with an important concept from Go-the-language. Renaming it to "Availability" because that's more descriptive.
