### PR TITLE
Adding common result struct

### DIFF
--- a/results.go
+++ b/results.go
@@ -1,7 +1,7 @@
-package openstack
+package gophercloud
 
 // CommonResult acts as a base struct that other results can embed. It contains
-// the deserialized JSON structured returned from the server (Resp), and any
+// the deserialized JSON structure returned from the server (Resp), and any
 // errors that might have occurred during transport or deserialization.
 type CommonResult struct {
 	Resp map[string]interface{}


### PR DESCRIPTION
Since we're moving towards individual `FooResult` structs for each operation, we probably need a common type to embed (otherwise lots of duplication). Typically you'd do something like this:

``` go
type CreateResult struct {
   openstack.CommonResult
}

type UpdateResult struct {
   openstack.CommonResult
   SomeHeader string
}
```

and then decorate with extra fields as necessary.
