### PR TITLE
[wip] Centralize authentication and HTTP logic on ServiceClient

### DIFF
--- a/openstack/identity/v3/endpoints/requests_test.go
+++ b/openstack/identity/v3/endpoints/requests_test.go
@@ -65,7 +65,7 @@ func TestCreateSuccessful(t *testing.T) {
 		Region:       "underground",
 		URL:          "https://1.2.3.4:9000/",
 		ServiceID:    "asdfasdfasdfasdf",
-	})
+	}).Extract()
 	if err != nil {
 		t.Fatalf("Unable to create an endpoint: %v", err)
 	}

--- a/openstack/identity/v3/endpoints/results.go
+++ b/openstack/identity/v3/endpoints/results.go
@@ -6,6 +6,45 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
+type endpointResult struct {
+	gophercloud.CommonResult
+}
+
+func (r endpointResult) Extract() (*Endpoint, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	var response struct {
+		Endpoint `mapstructure:"endpoint"`
+	}
+
+	err := mapstructure.Decode(r.Resp, &response)
+	return &response.Endpoint, err
+}
+
+// CreateResult is the uninterpreted response from a Create call.
+// Use the Extract() method, or an Extract function from an extension package, to interpret it.
+type CreateResult struct {
+	endpointResult
+}
+
+// createResultErr returns a CreateResult that contains only an error.
+func createResultErr(err error) CreateResult {
+	return CreateResult{endpointResult{gophercloud.CommonResult{Err: err}}}
+}
+
+// UpdateResult is the uninterpreted response from am Update call.
+// Use the Extract() method, or an Extract function from an extension package, to interpret it.
+type UpdateResult struct {
+	endpointResult
+}
+
+// updateResultErr returns an UpdateResult that contains only an error.
+func updateResultErr(err error) UpdateResult {
+	return UpdateResult{endpointResult{gophercloud.CommonResult{Err: err}}}
+}
+
 // Endpoint describes the entry point for another service's API.
 type Endpoint struct {
 	ID           string                   `mapstructure:"id" json:"id"`

--- a/service_client.go
+++ b/service_client.go
@@ -1,6 +1,10 @@
 package gophercloud
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/racker/perigee"
+)
 
 // ServiceClient stores details required to interact with a specific service API implemented by a provider.
 // Generally, you'll acquire these by calling the appropriate `New` method on a ProviderClient.
@@ -16,4 +20,24 @@ type ServiceClient struct {
 // ServiceURL constructs a URL for a resource belonging to this provider.
 func (client *ServiceClient) ServiceURL(parts ...string) string {
 	return client.Endpoint + strings.Join(parts, "/")
+}
+
+// RequestOptions contains extra information about how to perform a specific request.
+type RequestOptions struct {
+	ReqBody interface{}
+	OkCodes []int
+}
+
+// Request performs an authenticated request against the service endpoint.
+func (client *ServiceClient) Request(method, url string, options RequestOptions) CommonResult {
+	result := CommonResult{}
+
+	opts := perigee.Options{
+		MoreHeaders: client.Provider.AuthenticatedHeaders(),
+		ReqBody:     options.ReqBody,
+		OkCodes:     options.OkCodes,
+		Results:     &result.Resp,
+	}
+	_, result.Err = perigee.Request(method, url, opts)
+	return result
 }


### PR DESCRIPTION
Rather than rely on each service request to populate headers properly, it would make more sense to centralize the common logic in a `ServiceClient` method. This will also make it easier to implement automatic re-authentication or pluggable HTTP transport layers.

cc @jrperritt 
