### PR TITLE
Identity acceptance tests

### DIFF
--- a/acceptance/openstack/identity/v2/token_test.go
+++ b/acceptance/openstack/identity/v2/token_test.go
@@ -14,7 +14,7 @@ func TestAuthenticate(t *testing.T) {
 	service := unauthenticatedClient(t)
 
 	// Authenticated!
-	result := tokens2.Create(service, ao)
+	result := tokens2.Create(service, tokens2.WrapOptions(ao))
 
 	// Extract and print the token.
 	token, err := result.ExtractToken()


### PR DESCRIPTION
This fixes one of the build errors that crept into the acceptance tests:

```
ashl6947@MMN1F3FD58 ~/code/gophercloud (v0.2.0=) $ script/acceptancetest
# github.com/rackspace/gophercloud/acceptance/openstack/identity/v2
acceptance/openstack/identity/v2/token_test.go:17: cannot use ao (type gophercloud.AuthOptions) as type "github.com/rackspace/gophercloud/openstack/identity/v2/tokens".AuthOptionsBuilder in argument to "github.com/rackspace/gophercloud/openstack/identit:
    gophercloud.AuthOptions does not implement "github.com/rackspace/gophercloud/openstack/identity/v2/tokens".AuthOptionsBuilder (missing ToTokenCreateMap method)
```

Part of #241.
