### PR TITLE
remove redundant delete in security groups acceptance test

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/security_test.go
+++ b/acceptance/openstack/networking/v2/extensions/security_test.go
@@ -52,17 +52,14 @@ func TestSecurityGroupRules(t *testing.T) {
 	// create security group rule
 	ruleID := createSecRule(t, groupID)
 
+	// delete security group rule
+	defer deleteSecRule(t, ruleID)
+
 	// list security group rule
 	listSecRules(t)
 
 	// get security group rule
 	getSecRule(t, ruleID)
-
-	// delete security group rule
-	deleteSecRule(t, ruleID)
-
-	// delete security group
-	deleteSecGroup(t, groupID)
 }
 
 func createSecGroup(t *testing.T) string {


### PR DESCRIPTION
There was a `delete` deferred after the creation and then another at the end of the function, causing the acceptance test to fail. This PR cleans that up.
