### PR TITLE
Remove extraneous fmt.Printf calls.

### DIFF
--- a/acceptance/openstack/blockstorage/v1/volumes_test.go
+++ b/acceptance/openstack/blockstorage/v1/volumes_test.go
@@ -3,7 +3,6 @@
 package v1
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -68,7 +67,7 @@ func TestVolumes(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	fmt.Printf("Got volume: %+v\n", v)
+	t.Logf("Got volume: %+v\n", v)
 
 	if v.Name != "gophercloud-updated-volume" {
 		t.Errorf("Unable to update volume: Expected name: gophercloud-updated-volume\nActual name: %s", v.Name)

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -3,7 +3,6 @@
 package v2
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -42,7 +41,7 @@ func TestListServers(t *testing.T) {
 		return true, nil
 	})
 
-	fmt.Printf("--------\n%d servers listed on %d pages.\n", count, pages)
+	t.Logf("--------\n%d servers listed on %d pages.\n", count, pages)
 }
 
 func networkingClient() (*gophercloud.ServiceClient, error) {

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -49,7 +49,6 @@ func List(c *gophercloud.ServiceClient, containerName string, opts ListOptsBuild
 	if opts != nil {
 		full, query, err := opts.ToObjectListParams()
 		if err != nil {
-			fmt.Printf("Error building query string: %v", err)
 			return pagination.Pager{Err: err}
 		}
 		url += query

--- a/pagination/linked.go
+++ b/pagination/linked.go
@@ -39,8 +39,6 @@ func (current LinkedPageBase) NextPageURL() (string, error) {
 			return "", nil
 		}
 
-		fmt.Printf("key = %#v, path = %#v, value = %#v\n", key, path, value)
-
 		if len(path) > 0 {
 			submap, ok = value.(map[string]interface{})
 			if !ok {


### PR DESCRIPTION
Within test cases, t.Logf is better. Elsewhere, we shouldn't output at all.
