### PR TITLE
Don't use type-aliases for CreateOpts and UpdateOpts.

### DIFF
--- a/openstack/identity/v2/users/requests.go
+++ b/openstack/identity/v2/users/requests.go
@@ -28,6 +28,8 @@ var (
 	Disabled EnabledState = &iFalse
 )
 
+// CommonOpts are the parameters that are shared between CreateOpts and
+// UpdateOpts
 type CommonOpts struct {
 	// Either a name or username is required. When provided, the value must be
 	// unique or a 409 conflict error will be returned. If you provide a name but


### PR DESCRIPTION
They make the godoc output much less readable. The duplication is minimal, and I think having the documentation be better is a worthwhile tradeoff.
