### PR TITLE
Allow 304 from download requests

### DIFF
--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -125,7 +125,7 @@ func Download(c *gophercloud.ServiceClient, containerName, objectName string, op
 
 	resp, err := perigee.Request("GET", url, perigee.Options{
 		MoreHeaders: h,
-		OkCodes:     []int{200},
+		OkCodes:     []int{200, 304},
 	})
 
 	res.Body = resp.HttpResponse.Body


### PR DESCRIPTION
If you set `IfNoneMatch` or other settings on DownloadOpts, it is possible for Swift to return non-200, but it isn't an error, and I want to see the http Headers.... so allow 304 in addition to 200.
