### PR TITLE
use security groups and support assigning keys

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -135,9 +135,6 @@ type CreateOpts struct {
 	// AdminPass [optional] sets the root user password. If not set, a randomly-generated
 	// password will be created and returned in the response.
 	AdminPass string
-
-	//KeyName [optional] sets key pair name to be used
-	KeyName string
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -167,9 +164,6 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	}
 	if opts.AdminPass != "" {
 		server["adminPass"] = opts.AdminPass
-	}
-	if opts.KeyName != "" {
-		server["key_name"] = opts.KeyName
 	}
 
 	if len(opts.SecurityGroups) > 0 {


### PR DESCRIPTION
Previously the security groups option was checked on openstack server creation but not added to what was passed to the openstack API, this fixes that. Additionally you can now pass the key_name as a string.
