### PR TITLE
BFV bug

### DIFF
--- a/acceptance/rackspace/compute/v2/bootfromvolume_test.go
+++ b/acceptance/rackspace/compute/v2/bootfromvolume_test.go
@@ -41,6 +41,9 @@ func TestBootFromVolume(t *testing.T) {
 	}).Extract()
 	th.AssertNoErr(t, err)
 	t.Logf("Created server: %+v\n", server)
-	//defer deleteServer(t, client, server)
-	t.Logf("Deleting server [%s]...", name)
+	defer deleteServer(t, client, server)
+
+	getServer(t, client, server)
+
+	listServers(t, client)
 }

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -23,13 +23,8 @@ func (r serverResult) Extract() (*Server, error) {
 	}
 
 	config := &mapstructure.DecoderConfig{
-		DecodeHook: func(from reflect.Kind, to reflect.Kind, data interface{}) (interface{}, error) {
-			if (from == reflect.String) && (to == reflect.Map) {
-				return map[string]interface{}{}, nil
-			}
-			return data, nil
-		},
-		Result: &response,
+		DecodeHook: toMapFromString,
+		Result:     &response,
 	}
 	decoder, err := mapstructure.NewDecoder(config)
 	if err != nil {
@@ -186,13 +181,8 @@ func ExtractServers(page pagination.Page) ([]Server, error) {
 	}
 
 	config := &mapstructure.DecoderConfig{
-		DecodeHook: func(from reflect.Kind, to reflect.Kind, data interface{}) (interface{}, error) {
-			if (from == reflect.String) && (to == reflect.Map) {
-				return map[string]interface{}{}, nil
-			}
-			return data, nil
-		},
-		Result: &response,
+		DecodeHook: toMapFromString,
+		Result:     &response,
 	}
 	decoder, err := mapstructure.NewDecoder(config)
 	if err != nil {
@@ -271,4 +261,11 @@ func (r MetadatumResult) Extract() (map[string]string, error) {
 
 	err := mapstructure.Decode(r.Body, &response)
 	return response.Metadatum, err
+}
+
+func toMapFromString(from reflect.Kind, to reflect.Kind, data interface{}) (interface{}, error) {
+	if (from == reflect.String) && (to == reflect.Map) {
+		return map[string]interface{}{}, nil
+	}
+	return data, nil
 }


### PR DESCRIPTION
If a server is created via boot from volume, it won't have a map[string]interface{} type for the `image` field; it will instead be of type `string`. This PR allows for an `image` attribute of type string when retrieving a server created via bfv.