### PR TITLE
Omit the Content-Type header on an objects.Create call unless intentionally provided

### DIFF
--- a/openstack/objectstorage/v1/objects/fixtures.go
+++ b/openstack/objectstorage/v1/objects/fixtures.go
@@ -105,13 +105,31 @@ func HandleListObjectNamesSuccessfully(t *testing.T) {
 	})
 }
 
-// HandleCreateObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux that
-// responds with a `Create` response.
-func HandleCreateObjectSuccessfully(t *testing.T) {
+// HandleCreateTextObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler mux
+// that responds with a `Create` response. A Content-Type of "text/plain" is expected.
+func HandleCreateTextObjectSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "text/plain")
+		th.TestHeader(t, r, "Accept", "application/json")
+		w.WriteHeader(http.StatusCreated)
+	})
+}
+
+// HandleCreateTypelessObjectSuccessfully creates an HTTP handler at `/testContainer/testObject` on the test handler
+// mux that responds with a `Create` response. No Content-Type header may be present in the request, so that server-
+// side content-type detection will be triggered properly.
+func HandleCreateTypelessObjectSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/testContainer/testObject", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PUT")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
+
+		if contentType, present := r.Header["Content-Type"]; present {
+			t.Errorf("Expected Content-Type header to be omitted, but was %#v", contentType)
+		}
+
 		w.WriteHeader(http.StatusCreated)
 	})
 }

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -205,14 +205,20 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 		url += query
 	}
 
-	contentType := h["Content-Type"]
-
-	resp, err := perigee.Request("PUT", url, perigee.Options{
-		ContentType: contentType,
+	popts := perigee.Options{
 		ReqBody:     content,
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202},
-	})
+	}
+
+	if contentType, explicit := h["Content-Type"]; explicit {
+		popts.ContentType = contentType
+		delete(h, "Content-Type")
+	} else {
+		popts.OmitContentType = true
+	}
+
+	resp, err := perigee.Request("PUT", url, popts)
 	res.Header = resp.HttpResponse.Header
 	res.Err = err
 	return res

--- a/openstack/objectstorage/v1/objects/requests_test.go
+++ b/openstack/objectstorage/v1/objects/requests_test.go
@@ -83,11 +83,21 @@ func TestListObjectNames(t *testing.T) {
 func TestCreateObject(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleCreateObjectSuccessfully(t)
+	HandleCreateTextObjectSuccessfully(t)
 
 	content := bytes.NewBufferString("Did gyre and gimble in the wabe")
-	options := &CreateOpts{ContentType: "application/json"}
+	options := &CreateOpts{ContentType: "text/plain"}
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, options)
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestCreateObjectWithoutContentType(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateTypelessObjectSuccessfully(t)
+
+	content := bytes.NewBufferString("The sky was the color of television, tuned to a dead channel.")
+	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &CreateOpts{})
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/rackspace/objectstorage/v1/objects/delegate_test.go
+++ b/rackspace/objectstorage/v1/objects/delegate_test.go
@@ -66,11 +66,21 @@ func TestListObjectNames(t *testing.T) {
 func TestCreateObject(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	os.HandleCreateObjectSuccessfully(t)
+	os.HandleCreateTextObjectSuccessfully(t)
 
 	content := bytes.NewBufferString("Did gyre and gimble in the wabe")
-	options := &os.CreateOpts{ContentType: "application/json"}
+	options := &os.CreateOpts{ContentType: "text/plain"}
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, options)
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestCreateObjectWithoutContentType(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	os.HandleCreateTypelessObjectSuccessfully(t)
+
+	content := bytes.NewBufferString("The sky was the color of television, tuned to a dead channel.")
+	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &CreateOpts{})
 	th.AssertNoErr(t, res.Err)
 }
 

--- a/rackspace/objectstorage/v1/objects/delegate_test.go
+++ b/rackspace/objectstorage/v1/objects/delegate_test.go
@@ -80,7 +80,7 @@ func TestCreateObjectWithoutContentType(t *testing.T) {
 	os.HandleCreateTypelessObjectSuccessfully(t)
 
 	content := bytes.NewBufferString("The sky was the color of television, tuned to a dead channel.")
-	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &CreateOpts{})
+	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &os.CreateOpts{})
 	th.AssertNoErr(t, res.Err)
 }
 


### PR DESCRIPTION
To trigger server-side content type detection, the Content-Type header should be *omitted* from the `PUT` request used to upload an object to Swift.

Fixes #336.