### PR TITLE
Update Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ after_success:
   - go get github.com/mattn/goveralls
   - export PATH=$PATH:$HOME/gopath/bin/
   - goveralls 2k7PTU3xa474Hymwgdj6XjqenNfGTNkO8
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ install:
 go:
   - 1.1
   - 1.2
+  - 1.3
+  - 1.4
   - tip
 script: script/cibuild
 after_success:


### PR DESCRIPTION
This is a small change to update the `.travis.yml` configuration, to:

 * Include more recent releases of Go, namely 1.3 and 1.4.
 * Enable [Docker-based builds](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) to improve build speed.

Assuming the newer builds pass, it should be ready for merge as-is. :shipit: