### PR TITLE
Improve CDN service patch updates.

### DIFF
--- a/acceptance/rackspace/cdn/v1/service_test.go
+++ b/acceptance/rackspace/cdn/v1/service_test.go
@@ -60,17 +60,13 @@ func testServiceGet(t *testing.T, client *gophercloud.ServiceClient, id string) 
 }
 
 func testServiceUpdate(t *testing.T, client *gophercloud.ServiceClient, id string) {
-	updateOpts := os.UpdateOpts{
-		os.UpdateOpt{
-			Op:   os.Add,
-			Path: "/domains/-",
-			Value: map[string]interface{}{
-				"domain":   "newDomain.com",
-				"protocol": "http",
-			},
+	opts := []os.Patch{
+		os.Append{
+			Value: os.Domain{Domain: "newDomain.com", Protocol: "http"},
 		},
 	}
-	loc, err := services.Update(client, id, updateOpts).Extract()
+
+	loc, err := services.Update(client, id, opts).Extract()
 	th.AssertNoErr(t, err)
 	t.Logf("Successfully updated service at location: %s", loc)
 }

--- a/openstack/cdn/v1/services/fixtures.go
+++ b/openstack/cdn/v1/services/fixtures.go
@@ -344,6 +344,15 @@ func HandleUpdateCDNServiceSuccessfully(t *testing.T) {
 				{
 					"op": "remove",
 					"path": "/caching/8"
+				},
+				{
+					"op": "remove",
+					"path": "/caching"
+				},
+				{
+					"op": "replace",
+					"path": "/name",
+					"value": "differentServiceName"
 				}
     ]
    `)

--- a/openstack/cdn/v1/services/fixtures.go
+++ b/openstack/cdn/v1/services/fixtures.go
@@ -170,10 +170,10 @@ func HandleListCDNServiceSuccessfully(t *testing.T) {
 // HandleCreateCDNServiceSuccessfully creates an HTTP handler at `/services` on the test handler mux
 // that responds with a `Create` response.
 func HandleCreateCDNServiceSuccessfully(t *testing.T) {
-  th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
-    th.TestMethod(t, r, "POST")
-    th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-    th.TestJSONRequest(t, r, `
+	th.Mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, `
       {
         "name": "mywebsite.com",
         "domains": [
@@ -212,21 +212,21 @@ func HandleCreateCDNServiceSuccessfully(t *testing.T) {
         "flavor_id": "cdn"
       }
    `)
-   w.Header().Add("Location", "https://global.cdn.api.rackspacecloud.com/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0")
-   w.WriteHeader(http.StatusAccepted)
-  })
+		w.Header().Add("Location", "https://global.cdn.api.rackspacecloud.com/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0")
+		w.WriteHeader(http.StatusAccepted)
+	})
 }
 
 // HandleGetCDNServiceSuccessfully creates an HTTP handler at `/services/{id}` on the test handler mux
 // that responds with a `Get` response.
 func HandleGetCDNServiceSuccessfully(t *testing.T) {
-  th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
-    th.TestMethod(t, r, "GET")
-    th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+	th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(http.StatusOK)
-    fmt.Fprintf(w, `
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
     {
         "id": "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0",
         "name": "mywebsite.com",
@@ -299,16 +299,16 @@ func HandleGetCDNServiceSuccessfully(t *testing.T) {
         ]
     }
     `)
-  })
+	})
 }
 
 // HandleUpdateCDNServiceSuccessfully creates an HTTP handler at `/services/{id}` on the test handler mux
 // that responds with a `Update` response.
 func HandleUpdateCDNServiceSuccessfully(t *testing.T) {
-  th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
-    th.TestMethod(t, r, "PATCH")
-    th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-    th.TestJSONRequest(t, r, `
+	th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestJSONRequest(t, r, `
       [
         {
             "op": "replace",
@@ -321,22 +321,22 @@ func HandleUpdateCDNServiceSuccessfully(t *testing.T) {
         },
         {
             "op": "add",
-            "path": "/domains/0",
+            "path": "/domains/-",
             "value": {"domain": "added.mocksite4.com"}
         }
     ]
    `)
-   w.Header().Add("Location", "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0")
-   w.WriteHeader(http.StatusAccepted)
-  })
+		w.Header().Add("Location", "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0")
+		w.WriteHeader(http.StatusAccepted)
+	})
 }
 
 // HandleDeleteCDNServiceSuccessfully creates an HTTP handler at `/services/{id}` on the test handler mux
 // that responds with a `Delete` response.
 func HandleDeleteCDNServiceSuccessfully(t *testing.T) {
-  th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
-    th.TestMethod(t, r, "DELETE")
-    th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
-    w.WriteHeader(http.StatusAccepted)
-  })
+	th.Mux.HandleFunc("/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
 }

--- a/openstack/cdn/v1/services/fixtures.go
+++ b/openstack/cdn/v1/services/fixtures.go
@@ -310,20 +310,41 @@ func HandleUpdateCDNServiceSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 		th.TestJSONRequest(t, r, `
       [
-        {
-            "op": "replace",
-            "path": "/origins/0",
-            "value": {
-                "origin": "44.33.22.11",
-                "port": 80,
-                "ssl": false
-            }
-        },
-        {
-            "op": "add",
-            "path": "/domains/-",
-            "value": {"domain": "added.mocksite4.com"}
-        }
+				{
+					"op": "add",
+					"path": "/domains/-",
+					"value": {"domain": "appended.mocksite4.com"}
+				},
+				{
+					"op": "add",
+					"path": "/domains/4",
+					"value": {"domain": "inserted.mocksite4.com"}
+				},
+				{
+					"op": "add",
+					"path": "/domains",
+					"value": [
+						{"domain": "bulkadded1.mocksite4.com"},
+						{"domain": "bulkadded2.mocksite4.com"}
+					]
+				},
+				{
+					"op": "replace",
+					"path": "/origins/2",
+					"value": {"origin": "44.33.22.11", "port": 80, "ssl": false}
+				},
+				{
+					"op": "replace",
+					"path": "/origins",
+					"value": [
+						{"origin": "44.33.22.11", "port": 80, "ssl": false},
+						{"origin": "55.44.33.22", "port": 443, "ssl": true}
+					]
+				},
+				{
+					"op": "remove",
+					"path": "/caching/8"
+				}
     ]
    `)
 		w.Header().Add("Location", "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0")

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -254,22 +254,6 @@ var (
 	PathCaching = Path{baseElement: "caching"}
 )
 
-// UpdateOpts represents the attributes used when updating an existing CDN service.
-type UpdateOpts []UpdateOpt
-
-// UpdateOpt represents a single update to an existing service. Multiple updates
-// to a service can be submitted at the same time. See UpdateOpts.
-type UpdateOpt struct {
-	// Specifies the update operation to perform.
-	Op Op `json:"op"`
-	// Specifies the JSON Pointer location within the service's JSON representation
-	// of the service parameter being added, replaced or removed.
-	Path string `json:"path"`
-	// Specifies the actual value to be added or replaced. It is not required for
-	// the remove operation.
-	Value map[string]interface{} `json:"value,omitempty"`
-}
-
 type value interface {
 	toPatchValue() map[string]interface{}
 	appropriatePath() Path
@@ -328,33 +312,6 @@ func (r Removal) ToCDNServiceUpdateMap() map[string]interface{} {
 		"op":   "remove",
 		"path": r.Path.renderIndex(r.Index),
 	}
-}
-
-// ToCDNServiceUpdateMap casts an UpdateOpts struct to a map.
-func (opts UpdateOpts) ToCDNServiceUpdateMap() ([]map[string]interface{}, error) {
-	s := make([]map[string]interface{}, len(opts))
-
-	for i, opt := range opts {
-		if opt.Op != Add && opt.Op != Remove && opt.Op != Replace {
-			return nil, fmt.Errorf("Invalid Op: %v", opt.Op)
-		}
-		if opt.Op == "" {
-			return nil, no("Op")
-		}
-		if opt.Path == "" {
-			return nil, no("Path")
-		}
-		if opt.Op != Remove && opt.Value == nil {
-			return nil, no("Value")
-		}
-		s[i] = map[string]interface{}{
-			"op":    opt.Op,
-			"path":  opt.Path,
-			"value": opt.Value,
-		}
-	}
-
-	return s, nil
 }
 
 // Update accepts a slice of Patch operations (Addition, Replacement or Removal) and updates an

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -229,6 +229,31 @@ var (
 	Replace Op = "replace"
 )
 
+// Path is a JSON pointer location that indicates which service parameter is being added, replaced,
+// or removed.
+type Path struct {
+	baseElement string
+}
+
+func (p Path) renderDash() string {
+	return fmt.Sprintf("/%s/-", p.baseElement)
+}
+
+func (p Path) renderIndex(index int64) string {
+	return fmt.Sprintf("/%s/%d", p.baseElement, index)
+}
+
+var (
+	// PathDomains indicates that an update operation is to be performed on a Domain.
+	PathDomains = Path{baseElement: "domains"}
+
+	// PathOrigins indicates that an update operation is to be performed on an Origin.
+	PathOrigins = Path{baseElement: "origins"}
+
+	// PathCaching indicates that an update operation is to be performed on a CacheRule.
+	PathCaching = Path{baseElement: "caching"}
+)
+
 // UpdateOpts represents the attributes used when updating an existing CDN service.
 type UpdateOpts []UpdateOpt
 

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -275,6 +275,12 @@ type value interface {
 	appropriatePath() Path
 }
 
+// Patch represents a single update to an existing Service. Multiple updates to a service can be
+// submitted at the same time.
+type Patch interface {
+	ToCDNServiceUpdateMap() map[string]interface{}
+}
+
 // ToCDNServiceUpdateMap casts an UpdateOpts struct to a map.
 func (opts UpdateOpts) ToCDNServiceUpdateMap() ([]map[string]interface{}, error) {
 	s := make([]map[string]interface{}, len(opts))

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -209,26 +209,6 @@ func Get(c *gophercloud.ServiceClient, idOrURL string) GetResult {
 	return res
 }
 
-// UpdateOptsBuilder is the interface options structs have to satisfy in order
-// to be used in the main Update operation in this package. Since many
-// extensions decorate or modify the common logic, it is useful for them to
-// satisfy a basic interface in order for them to be used.
-type UpdateOptsBuilder interface {
-	ToCDNServiceUpdateMap() ([]map[string]interface{}, error)
-}
-
-// Op represents an update operation.
-type Op string
-
-var (
-	// Add is a constant used for performing a "add" operation when updating.
-	Add Op = "add"
-	// Remove is a constant used for performing a "remove" operation when updating.
-	Remove Op = "remove"
-	// Replace is a constant used for performing a "replace" operation when updating.
-	Replace Op = "replace"
-)
-
 // Path is a JSON pointer location that indicates which service parameter is being added, replaced,
 // or removed.
 type Path struct {

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -281,6 +281,55 @@ type Patch interface {
 	ToCDNServiceUpdateMap() map[string]interface{}
 }
 
+// Addition is a Patch that requests the addition of one or more values (Domains, Origins, or
+// CacheRules) to a Service. Pass it to the Update function as part of the Patch slice.
+type Addition struct {
+	Value value
+}
+
+// ToCDNServiceUpdateMap converts an Addition into a request body fragment suitable for the
+// Update call.
+func (a Addition) ToCDNServiceUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "add",
+		"path":  a.Value.appropriatePath().renderDash(),
+		"value": a.Value.toPatchValue(),
+	}
+}
+
+// Replacement is a Patch that alters a specific service parameter (Domain, Origin, or CacheRule)
+// in-place by index. Pass it to the Update function as part of the Patch slice.
+type Replacement struct {
+	Value value
+	Index int64
+}
+
+// ToCDNServiceUpdateMap converts a Replacement into a request body fragment suitable for the
+// Update call.
+func (r Replacement) ToCDNServiceUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  r.Value.appropriatePath().renderIndex(r.Index),
+		"value": r.Value.toPatchValue(),
+	}
+}
+
+// Removal is a Patch that requests the removal of a service parameter (Domain, Origin, or
+// CacheRule) by index. Pass it to the Update function as part of the Patch slice.
+type Removal struct {
+	Path  Path
+	Index int64
+}
+
+// ToCDNServiceUpdateMap converts a Removal into a request body fragment suitable for the
+// Update call.
+func (r Removal) ToCDNServiceUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":   "remove",
+		"path": r.Path.renderIndex(r.Index),
+	}
+}
+
 // ToCDNServiceUpdateMap casts an UpdateOpts struct to a map.
 func (opts UpdateOpts) ToCDNServiceUpdateMap() ([]map[string]interface{}, error) {
 	s := make([]map[string]interface{}, len(opts))

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -235,7 +235,7 @@ var (
 )
 
 type value interface {
-	toPatchValue() map[string]interface{}
+	toPatchValue() interface{}
 	appropriatePath() Path
 }
 

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -303,20 +303,40 @@ func (r Replacement) ToCDNServiceUpdateMap() map[string]interface{} {
 	}
 }
 
+// NameReplacement specifically updates the Service name. Pass it to the Update function as part
+// of the Patch slice.
+type NameReplacement struct {
+	NewName string
+}
+
+// ToCDNServiceUpdateMap converts a NameReplacement into a request body fragment suitable for the
+// Update call.
+func (r NameReplacement) ToCDNServiceUpdateMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/name",
+		"value": r.NewName,
+	}
+}
+
 // Removal is a Patch that requests the removal of a service parameter (Domain, Origin, or
 // CacheRule) by index. Pass it to the Update function as part of the Patch slice.
 type Removal struct {
 	Path  Path
 	Index int64
+	All   bool
 }
 
 // ToCDNServiceUpdateMap converts a Removal into a request body fragment suitable for the
 // Update call.
 func (r Removal) ToCDNServiceUpdateMap() map[string]interface{} {
-	return map[string]interface{}{
-		"op":   "remove",
-		"path": r.Path.renderIndex(r.Index),
+	result := map[string]interface{}{"op": "remove"}
+	if r.All {
+		result["path"] = r.Path.renderRoot()
+	} else {
+		result["path"] = r.Path.renderIndex(r.Index)
 	}
+	return result
 }
 
 // Update accepts a slice of Patch operations (Insertion, Append, Replacement or Removal) and

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -270,6 +270,11 @@ type UpdateOpt struct {
 	Value map[string]interface{} `json:"value,omitempty"`
 }
 
+type value interface {
+	toPatchValue() map[string]interface{}
+	appropriatePath() Path
+}
+
 // ToCDNServiceUpdateMap casts an UpdateOpts struct to a map.
 func (opts UpdateOpts) ToCDNServiceUpdateMap() ([]map[string]interface{}, error) {
 	s := make([]map[string]interface{}, len(opts))

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -215,6 +215,10 @@ type Path struct {
 	baseElement string
 }
 
+func (p Path) renderRoot() string {
+	return "/" + p.baseElement
+}
+
 func (p Path) renderDash() string {
 	return fmt.Sprintf("/%s/-", p.baseElement)
 }
@@ -237,6 +241,7 @@ var (
 type value interface {
 	toPatchValue() interface{}
 	appropriatePath() Path
+	renderRootOr(func(p Path) string) string
 }
 
 // Patch represents a single update to an existing Service. Multiple updates to a service can be
@@ -258,7 +263,7 @@ type Insertion struct {
 func (i Insertion) ToCDNServiceUpdateMap() map[string]interface{} {
 	return map[string]interface{}{
 		"op":    "add",
-		"path":  i.Value.appropriatePath().renderIndex(i.Index),
+		"path":  i.Value.renderRootOr(func(p Path) string { return p.renderIndex(i.Index) }),
 		"value": i.Value.toPatchValue(),
 	}
 }
@@ -276,7 +281,7 @@ type Append struct {
 func (a Append) ToCDNServiceUpdateMap() map[string]interface{} {
 	return map[string]interface{}{
 		"op":    "add",
-		"path":  a.Value.appropriatePath().renderDash(),
+		"path":  a.Value.renderRootOr(func(p Path) string { return p.renderDash() }),
 		"value": a.Value.toPatchValue(),
 	}
 }
@@ -293,7 +298,7 @@ type Replacement struct {
 func (r Replacement) ToCDNServiceUpdateMap() map[string]interface{} {
 	return map[string]interface{}{
 		"op":    "replace",
-		"path":  r.Value.appropriatePath().renderIndex(r.Index),
+		"path":  r.Value.renderRootOr(func(p Path) string { return p.renderIndex(r.Index) }),
 		"value": r.Value.toPatchValue(),
 	}
 }

--- a/openstack/cdn/v1/services/requests_test.go
+++ b/openstack/cdn/v1/services/requests_test.go
@@ -331,6 +331,15 @@ func TestSuccessfulUpdate(t *testing.T) {
 			Index: 8,
 			Path:  PathCaching,
 		},
+		// Bulk removal
+		Removal{
+			All:  true,
+			Path: PathCaching,
+		},
+		// Service name replacement
+		NameReplacement{
+			NewName: "differentServiceName",
+		},
 	}
 
 	actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", ops).Extract()

--- a/openstack/cdn/v1/services/requests_test.go
+++ b/openstack/cdn/v1/services/requests_test.go
@@ -307,7 +307,7 @@ func TestSuccessfulUpdate(t *testing.T) {
 			},
 			Index: 0,
 		},
-		Addition{
+		Append{
 			Value: Domain{Domain: "added.mocksite4.com"},
 		},
 	}

--- a/openstack/cdn/v1/services/requests_test.go
+++ b/openstack/cdn/v1/services/requests_test.go
@@ -129,8 +129,8 @@ func TestList(t *testing.T) {
 					},
 				},
 				Restrictions: []Restriction{},
-				FlavorID: "europe",
-				Status:   "deployed",
+				FlavorID:     "europe",
+				Status:       "deployed",
 				Links: []gophercloud.Link{
 					gophercloud.Link{
 						Href: "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f1",
@@ -160,204 +160,169 @@ func TestList(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-  th.SetupHTTP()
-  defer th.TeardownHTTP()
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
 
-  HandleCreateCDNServiceSuccessfully(t)
+	HandleCreateCDNServiceSuccessfully(t)
 
-  createOpts := CreateOpts{
-    Name: "mywebsite.com",
-    Domains: []Domain{
-      Domain{
-        Domain: "www.mywebsite.com",
-      },
-      Domain{
-        Domain: "blog.mywebsite.com",
-      },
-    },
-    Origins: []Origin{
-      Origin{
-        Origin: "mywebsite.com",
-        Port: 80,
-        SSL: false,
-      },
-    },
-    Restrictions: []Restriction{
-      Restriction{
-        Name: "website only",
-        Rules: []RestrictionRule{
-          RestrictionRule{
-            Name: "mywebsite.com",
-            Referrer: "www.mywebsite.com",
-          },
-        },
-      },
-    },
-    Caching: []CacheRule{
-      CacheRule{
-        Name: "default",
-        TTL: 3600,
-      },
-    },
-    FlavorID: "cdn",
-  }
+	createOpts := CreateOpts{
+		Name: "mywebsite.com",
+		Domains: []Domain{
+			Domain{
+				Domain: "www.mywebsite.com",
+			},
+			Domain{
+				Domain: "blog.mywebsite.com",
+			},
+		},
+		Origins: []Origin{
+			Origin{
+				Origin: "mywebsite.com",
+				Port:   80,
+				SSL:    false,
+			},
+		},
+		Restrictions: []Restriction{
+			Restriction{
+				Name: "website only",
+				Rules: []RestrictionRule{
+					RestrictionRule{
+						Name:     "mywebsite.com",
+						Referrer: "www.mywebsite.com",
+					},
+				},
+			},
+		},
+		Caching: []CacheRule{
+			CacheRule{
+				Name: "default",
+				TTL:  3600,
+			},
+		},
+		FlavorID: "cdn",
+	}
 
-  expected := "https://global.cdn.api.rackspacecloud.com/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
-  actual, err := Create(fake.ServiceClient(), createOpts).Extract()
-  th.AssertNoErr(t, err)
-  th.AssertEquals(t, expected, actual)
+	expected := "https://global.cdn.api.rackspacecloud.com/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
+	actual, err := Create(fake.ServiceClient(), createOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestGet(t *testing.T) {
-  th.SetupHTTP()
-  defer th.TeardownHTTP()
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
 
-  HandleGetCDNServiceSuccessfully(t)
+	HandleGetCDNServiceSuccessfully(t)
 
-  expected := &Service{
-    ID:   "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0",
-    Name: "mywebsite.com",
-    Domains: []Domain{
-      Domain{
-        Domain: "www.mywebsite.com",
-        Protocol: "http",
-      },
-    },
-    Origins: []Origin{
-      Origin{
-        Origin: "mywebsite.com",
-        Port:   80,
-        SSL:    false,
-      },
-    },
-    Caching: []CacheRule{
-      CacheRule{
-        Name: "default",
-        TTL:  3600,
-      },
-      CacheRule{
-        Name: "home",
-        TTL:  17200,
-        Rules: []TTLRule{
-          TTLRule{
-            Name:       "index",
-            RequestURL: "/index.htm",
-          },
-        },
-      },
-      CacheRule{
-        Name: "images",
-        TTL:  12800,
-        Rules: []TTLRule{
-          TTLRule{
-            Name:       "images",
-            RequestURL: "*.png",
-          },
-        },
-      },
-    },
-    Restrictions: []Restriction{
-      Restriction{
-        Name: "website only",
-        Rules: []RestrictionRule{
-          RestrictionRule{
-            Name:     "mywebsite.com",
-            Referrer: "www.mywebsite.com",
-          },
-        },
-      },
-    },
-    FlavorID: "cdn",
-    Status:   "deployed",
-    Errors:   []Error{},
-    Links: []gophercloud.Link{
-      gophercloud.Link{
-        Href: "https://global.cdn.api.rackspacecloud.com/v1.0/110011/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0",
-        Rel:  "self",
-      },
-      gophercloud.Link{
-        Href: "blog.mywebsite.com.cdn1.raxcdn.com",
-        Rel:  "access_url",
-      },
-      gophercloud.Link{
-        Href: "https://global.cdn.api.rackspacecloud.com/v1.0/110011/flavors/cdn",
-        Rel:  "flavor",
-      },
-    },
-  }
+	expected := &Service{
+		ID:   "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0",
+		Name: "mywebsite.com",
+		Domains: []Domain{
+			Domain{
+				Domain:   "www.mywebsite.com",
+				Protocol: "http",
+			},
+		},
+		Origins: []Origin{
+			Origin{
+				Origin: "mywebsite.com",
+				Port:   80,
+				SSL:    false,
+			},
+		},
+		Caching: []CacheRule{
+			CacheRule{
+				Name: "default",
+				TTL:  3600,
+			},
+			CacheRule{
+				Name: "home",
+				TTL:  17200,
+				Rules: []TTLRule{
+					TTLRule{
+						Name:       "index",
+						RequestURL: "/index.htm",
+					},
+				},
+			},
+			CacheRule{
+				Name: "images",
+				TTL:  12800,
+				Rules: []TTLRule{
+					TTLRule{
+						Name:       "images",
+						RequestURL: "*.png",
+					},
+				},
+			},
+		},
+		Restrictions: []Restriction{
+			Restriction{
+				Name: "website only",
+				Rules: []RestrictionRule{
+					RestrictionRule{
+						Name:     "mywebsite.com",
+						Referrer: "www.mywebsite.com",
+					},
+				},
+			},
+		},
+		FlavorID: "cdn",
+		Status:   "deployed",
+		Errors:   []Error{},
+		Links: []gophercloud.Link{
+			gophercloud.Link{
+				Href: "https://global.cdn.api.rackspacecloud.com/v1.0/110011/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0",
+				Rel:  "self",
+			},
+			gophercloud.Link{
+				Href: "blog.mywebsite.com.cdn1.raxcdn.com",
+				Rel:  "access_url",
+			},
+			gophercloud.Link{
+				Href: "https://global.cdn.api.rackspacecloud.com/v1.0/110011/flavors/cdn",
+				Rel:  "flavor",
+			},
+		},
+	}
 
-
-  actual, err := Get(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0").Extract()
-  th.AssertNoErr(t, err)
-  th.AssertDeepEquals(t, expected, actual)
+	actual, err := Get(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expected, actual)
 }
 
 func TestSuccessfulUpdate(t *testing.T) {
-  th.SetupHTTP()
-  defer th.TeardownHTTP()
-
-  HandleUpdateCDNServiceSuccessfully(t)
-
-  expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
-  updateOpts := UpdateOpts{
-    UpdateOpt{
-      Op: Replace,
-      Path: "/origins/0",
-      Value: map[string]interface{}{
-        "origin": "44.33.22.11",
-        "port": 80,
-        "ssl": false,
-      },
-    },
-    UpdateOpt{
-      Op: Add,
-      Path: "/domains/0",
-      Value: map[string]interface{}{
-        "domain": "added.mocksite4.com",
-      },
-    },
-  }
-  actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", updateOpts).Extract()
-  th.AssertNoErr(t, err)
-  th.AssertEquals(t, expected, actual)
-}
-
-func TestUnsuccessfulUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
 	HandleUpdateCDNServiceSuccessfully(t)
 
-	updateOpts := UpdateOpts{
-		UpdateOpt{
-			Op: "Foo",
-			Path: "/origins/0",
-			Value: map[string]interface{}{
-				"origin": "44.33.22.11",
-				"port": 80,
-				"ssl": false,
+	expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
+	ops := []Patch{
+		Replacement{
+			Value: Origin{
+				Origin: "44.33.22.11",
+				Port:   80,
+				SSL:    false,
 			},
+			Index: 0,
 		},
-		UpdateOpt{
-			Op: Add,
-			Path: "/domains/0",
-			Value: map[string]interface{}{
-				"domain": "added.mocksite4.com",
-			},
+		Addition{
+			Value: Domain{Domain: "added.mocksite4.com"},
 		},
 	}
-	_, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", updateOpts).Extract()
-	if err == nil {
-		t.Errorf("Expected error during TestUnsuccessfulUpdate but didn't get one.")
-	}
+
+	actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", ops).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, expected, actual)
 }
 
 func TestDelete(t *testing.T) {
-  th.SetupHTTP()
-  defer th.TeardownHTTP()
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
 
-  HandleDeleteCDNServiceSuccessfully(t)
+	HandleDeleteCDNServiceSuccessfully(t)
 
-  err := Delete(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0").ExtractErr()
-  th.AssertNoErr(t, err)
+	err := Delete(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0").ExtractErr()
+	th.AssertNoErr(t, err)
 }

--- a/openstack/cdn/v1/services/requests_test.go
+++ b/openstack/cdn/v1/services/requests_test.go
@@ -299,16 +299,37 @@ func TestSuccessfulUpdate(t *testing.T) {
 
 	expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
 	ops := []Patch{
-		Replacement{
-			Value: Origin{
-				Origin: "44.33.22.11",
-				Port:   80,
-				SSL:    false,
-			},
-			Index: 0,
+		// Append a single Domain
+		Append{Value: Domain{Domain: "appended.mocksite4.com"}},
+		// Insert a single Domain
+		Insertion{
+			Index: 4,
+			Value: Domain{Domain: "inserted.mocksite4.com"},
 		},
+		// Bulk addition
 		Append{
-			Value: Domain{Domain: "added.mocksite4.com"},
+			Value: DomainList{
+				Domain{Domain: "bulkadded1.mocksite4.com"},
+				Domain{Domain: "bulkadded2.mocksite4.com"},
+			},
+		},
+		// Replace a single Origin
+		Replacement{
+			Index: 2,
+			Value: Origin{Origin: "44.33.22.11", Port: 80, SSL: false},
+		},
+		// Bulk replace Origins
+		Replacement{
+			Index: 0, // Ignored
+			Value: OriginList{
+				Origin{Origin: "44.33.22.11", Port: 80, SSL: false},
+				Origin{Origin: "55.44.33.22", Port: 443, SSL: true},
+			},
+		},
+		// Remove a single CacheRule
+		Removal{
+			Index: 8,
+			Path:  PathCaching,
 		},
 	}
 

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -17,7 +17,7 @@ type Domain struct {
 	Protocol string `mapstructure:"protocol" json:"protocol,omitempty"`
 }
 
-func (d Domain) toPatchValue() map[string]interface{} {
+func (d Domain) toPatchValue() interface{} {
 	r := make(map[string]interface{})
 	r["domain"] = d.Domain
 	if d.Protocol != "" {
@@ -27,6 +27,21 @@ func (d Domain) toPatchValue() map[string]interface{} {
 }
 
 func (d Domain) appropriatePath() Path {
+	return PathDomains
+}
+
+// DomainList provides a useful way to perform bulk operations in a single Patch.
+type DomainList []Domain
+
+func (list DomainList) toPatchValue() interface{} {
+	r := make([]interface{}, len(list))
+	for i, domain := range list {
+		r[i] = domain.toPatchValue()
+	}
+	return r
+}
+
+func (list DomainList) appropriatePath() Path {
 	return PathDomains
 }
 
@@ -52,7 +67,7 @@ type Origin struct {
 	Rules []OriginRule `mapstructure:"rules" json:"rules,omitempty"`
 }
 
-func (o Origin) toPatchValue() map[string]interface{} {
+func (o Origin) toPatchValue() interface{} {
 	r := make(map[string]interface{})
 	r["origin"] = o.Origin
 	r["port"] = o.Port
@@ -69,6 +84,21 @@ func (o Origin) toPatchValue() map[string]interface{} {
 }
 
 func (o Origin) appropriatePath() Path {
+	return PathOrigins
+}
+
+// OriginList provides a useful way to perform bulk operations in a single Patch.
+type OriginList []Domain
+
+func (list OriginList) toPatchValue() interface{} {
+	r := make([]interface{}, len(list))
+	for i, origin := range list {
+		r[i] = origin.toPatchValue()
+	}
+	return r
+}
+
+func (list OriginList) appropriatePath() Path {
 	return PathOrigins
 }
 
@@ -90,7 +120,7 @@ type CacheRule struct {
 	Rules []TTLRule `mapstructure:"rules" json:"rules,omitempty"`
 }
 
-func (c CacheRule) toPatchValue() map[string]interface{} {
+func (c CacheRule) toPatchValue() interface{} {
 	r := make(map[string]interface{})
 	r["name"] = c.Name
 	r["ttl"] = c.TTL
@@ -104,6 +134,21 @@ func (c CacheRule) toPatchValue() map[string]interface{} {
 }
 
 func (c CacheRule) appropriatePath() Path {
+	return PathCaching
+}
+
+// CacheRuleList provides a useful way to perform bulk operations in a single Patch.
+type CacheRuleList []Domain
+
+func (list CacheRuleList) toPatchValue() interface{} {
+	r := make([]interface{}, len(list))
+	for i, rule := range list {
+		r[i] = rule.toPatchValue()
+	}
+	return r
+}
+
+func (list CacheRuleList) appropriatePath() Path {
 	return PathCaching
 }
 

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -30,6 +30,10 @@ func (d Domain) appropriatePath() Path {
 	return PathDomains
 }
 
+func (d Domain) renderRootOr(render func(p Path) string) string {
+	return render(d.appropriatePath())
+}
+
 // DomainList provides a useful way to perform bulk operations in a single Patch.
 type DomainList []Domain
 
@@ -43,6 +47,10 @@ func (list DomainList) toPatchValue() interface{} {
 
 func (list DomainList) appropriatePath() Path {
 	return PathDomains
+}
+
+func (list DomainList) renderRootOr(_ func(p Path) string) string {
+	return list.appropriatePath().renderRoot()
 }
 
 // OriginRule represents a rule that defines when an origin should be accessed.
@@ -87,6 +95,10 @@ func (o Origin) appropriatePath() Path {
 	return PathOrigins
 }
 
+func (o Origin) renderRootOr(render func(p Path) string) string {
+	return render(o.appropriatePath())
+}
+
 // OriginList provides a useful way to perform bulk operations in a single Patch.
 type OriginList []Domain
 
@@ -100,6 +112,10 @@ func (list OriginList) toPatchValue() interface{} {
 
 func (list OriginList) appropriatePath() Path {
 	return PathOrigins
+}
+
+func (list OriginList) renderRootOr(_ func(p Path) string) string {
+	return list.appropriatePath().renderRoot()
 }
 
 // TTLRule specifies a rule that determines if a TTL should be applied to an asset.
@@ -137,6 +153,10 @@ func (c CacheRule) appropriatePath() Path {
 	return PathCaching
 }
 
+func (c CacheRule) renderRootOr(render func(p Path) string) string {
+	return render(c.appropriatePath())
+}
+
 // CacheRuleList provides a useful way to perform bulk operations in a single Patch.
 type CacheRuleList []Domain
 
@@ -150,6 +170,10 @@ func (list CacheRuleList) toPatchValue() interface{} {
 
 func (list CacheRuleList) appropriatePath() Path {
 	return PathCaching
+}
+
+func (list CacheRuleList) renderRootOr(_ func(p Path) string) string {
+	return list.appropriatePath().renderRoot()
 }
 
 // RestrictionRule specifies a rule that determines if this restriction should be applied to an asset.

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -17,6 +17,19 @@ type Domain struct {
 	Protocol string `mapstructure:"protocol" json:"protocol,omitempty"`
 }
 
+func (d Domain) toPatchValue() map[string]interface{} {
+	r := make(map[string]interface{})
+	r["domain"] = d.Domain
+	if d.Protocol != "" {
+		r["protocol"] = d.Protocol
+	}
+	return r
+}
+
+func (d Domain) appropriatePath() Path {
+	return PathDomains
+}
+
 // OriginRule represents a rule that defines when an origin should be accessed.
 type OriginRule struct {
 	// Specifies the name of this rule.
@@ -39,6 +52,24 @@ type Origin struct {
 	Rules []OriginRule `mapstructure:"rules" json:"rules,omitempty"`
 }
 
+func (o Origin) toPatchValue() map[string]interface{} {
+	r := make(map[string]interface{})
+	r["origin"] = o.Origin
+	r["port"] = o.Port
+	r["ssl"] = o.SSL
+	r["rules"] = make([]map[string]interface{}, len(o.Rules))
+	for index, rule := range o.Rules {
+		submap := r["rules"].([]map[string]interface{})[index]
+		submap["name"] = rule.Name
+		submap["request_url"] = rule.RequestURL
+	}
+	return r
+}
+
+func (o Origin) appropriatePath() Path {
+	return PathOrigins
+}
+
 // TTLRule specifies a rule that determines if a TTL should be applied to an asset.
 type TTLRule struct {
 	// Specifies the name of this rule.
@@ -55,6 +86,23 @@ type CacheRule struct {
 	TTL int `mapstructure:"ttl" json:"ttl"`
 	// Specifies a collection of rules that determine if this TTL should be applied to an asset.
 	Rules []TTLRule `mapstructure:"rules" json:"rules,omitempty"`
+}
+
+func (c CacheRule) toPatchValue() map[string]interface{} {
+	r := make(map[string]interface{})
+	r["name"] = c.Name
+	r["ttl"] = c.TTL
+	r["rules"] = make([]map[string]interface{}, len(c.Rules))
+	for index, rule := range c.Rules {
+		submap := r["rules"].([]map[string]interface{})[index]
+		submap["name"] = rule.Name
+		submap["request_url"] = rule.RequestURL
+	}
+	return r
+}
+
+func (c CacheRule) appropriatePath() Path {
+	return PathCaching
 }
 
 // RestrictionRule specifies a rule that determines if this restriction should be applied to an asset.

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -100,7 +100,7 @@ func (o Origin) renderRootOr(render func(p Path) string) string {
 }
 
 // OriginList provides a useful way to perform bulk operations in a single Patch.
-type OriginList []Domain
+type OriginList []Origin
 
 func (list OriginList) toPatchValue() interface{} {
 	r := make([]interface{}, len(list))
@@ -158,7 +158,7 @@ func (c CacheRule) renderRootOr(render func(p Path) string) string {
 }
 
 // CacheRuleList provides a useful way to perform bulk operations in a single Patch.
-type CacheRuleList []Domain
+type CacheRuleList []CacheRule
 
 func (list CacheRuleList) toPatchValue() interface{} {
 	r := make([]interface{}, len(list))

--- a/openstack/cdn/v1/services/results.go
+++ b/openstack/cdn/v1/services/results.go
@@ -57,11 +57,13 @@ func (o Origin) toPatchValue() map[string]interface{} {
 	r["origin"] = o.Origin
 	r["port"] = o.Port
 	r["ssl"] = o.SSL
-	r["rules"] = make([]map[string]interface{}, len(o.Rules))
-	for index, rule := range o.Rules {
-		submap := r["rules"].([]map[string]interface{})[index]
-		submap["name"] = rule.Name
-		submap["request_url"] = rule.RequestURL
+	if len(o.Rules) > 0 {
+		r["rules"] = make([]map[string]interface{}, len(o.Rules))
+		for index, rule := range o.Rules {
+			submap := r["rules"].([]map[string]interface{})[index]
+			submap["name"] = rule.Name
+			submap["request_url"] = rule.RequestURL
+		}
 	}
 	return r
 }

--- a/rackspace/cdn/v1/services/delegate.go
+++ b/rackspace/cdn/v1/services/delegate.go
@@ -27,8 +27,8 @@ func Get(c *gophercloud.ServiceClient, id string) os.GetResult {
 
 // Update accepts a UpdateOpts struct and updates an existing CDN service using
 // the values provided.
-func Update(c *gophercloud.ServiceClient, id string, opts os.UpdateOptsBuilder) os.UpdateResult {
-	return os.Update(c, id, opts)
+func Update(c *gophercloud.ServiceClient, id string, patches []os.Patch) os.UpdateResult {
+	return os.Update(c, id, patches)
 }
 
 // Delete accepts a unique ID and deletes the CDN service associated with it.

--- a/rackspace/cdn/v1/services/delegate_test.go
+++ b/rackspace/cdn/v1/services/delegate_test.go
@@ -308,7 +308,7 @@ func TestSuccessfulUpdate(t *testing.T) {
 			},
 			Index: 0,
 		},
-		os.Addition{
+		os.Append{
 			Value: os.Domain{Domain: "added.mocksite4.com"},
 		},
 	}

--- a/rackspace/cdn/v1/services/delegate_test.go
+++ b/rackspace/cdn/v1/services/delegate_test.go
@@ -299,57 +299,23 @@ func TestSuccessfulUpdate(t *testing.T) {
 	os.HandleUpdateCDNServiceSuccessfully(t)
 
 	expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
-	updateOpts := os.UpdateOpts{
-		os.UpdateOpt{
-			Op:   os.Replace,
-			Path: "/origins/0",
-			Value: map[string]interface{}{
-				"origin": "44.33.22.11",
-				"port":   80,
-				"ssl":    false,
+	ops := []os.Patch{
+		os.Replacement{
+			Value: os.Origin{
+				Origin: "44.33.22.11",
+				Port:   80,
+				SSL:    false,
 			},
+			Index: 0,
 		},
-		os.UpdateOpt{
-			Op:   os.Add,
-			Path: "/domains/0",
-			Value: map[string]interface{}{
-				"domain": "added.mocksite4.com",
-			},
+		os.Addition{
+			Value: os.Domain{Domain: "added.mocksite4.com"},
 		},
 	}
-	actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", updateOpts).Extract()
+
+	actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", ops).Extract()
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, expected, actual)
-}
-
-func TestUnsuccessfulUpdate(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	os.HandleUpdateCDNServiceSuccessfully(t)
-
-	updateOpts := os.UpdateOpts{
-		os.UpdateOpt{
-			Op: "Foo",
-			Path: "/origins/0",
-			Value: map[string]interface{}{
-				"origin": "44.33.22.11",
-				"port": 80,
-				"ssl": false,
-				},
-			},
-		os.UpdateOpt{
-			Op: os.Add,
-			Path: "/domains/0",
-			Value: map[string]interface{}{
-				"domain": "added.mocksite4.com",
-			},
-		},
-	}
-	_, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", updateOpts).Extract()
-	if err == nil {
-		t.Errorf("Expected error during TestUnsuccessfulUpdate but didn't get one.")
-	}
 }
 
 func TestDelete(t *testing.T) {

--- a/rackspace/cdn/v1/services/delegate_test.go
+++ b/rackspace/cdn/v1/services/delegate_test.go
@@ -332,6 +332,15 @@ func TestSuccessfulUpdate(t *testing.T) {
 			Index: 8,
 			Path:  os.PathCaching,
 		},
+		// Bulk removal
+		os.Removal{
+			All:  true,
+			Path: os.PathCaching,
+		},
+		// Service name replacement
+		os.NameReplacement{
+			NewName: "differentServiceName",
+		},
 	}
 
 	actual, err := Update(fake.ServiceClient(), "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", ops).Extract()

--- a/rackspace/cdn/v1/services/delegate_test.go
+++ b/rackspace/cdn/v1/services/delegate_test.go
@@ -300,16 +300,37 @@ func TestSuccessfulUpdate(t *testing.T) {
 
 	expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
 	ops := []os.Patch{
-		os.Replacement{
-			Value: os.Origin{
-				Origin: "44.33.22.11",
-				Port:   80,
-				SSL:    false,
-			},
-			Index: 0,
+		// Append a single Domain
+		os.Append{Value: os.Domain{Domain: "appended.mocksite4.com"}},
+		// Insert a single Domain
+		os.Insertion{
+			Index: 4,
+			Value: os.Domain{Domain: "inserted.mocksite4.com"},
 		},
+		// Bulk addition
 		os.Append{
-			Value: os.Domain{Domain: "added.mocksite4.com"},
+			Value: os.DomainList{
+				os.Domain{Domain: "bulkadded1.mocksite4.com"},
+				os.Domain{Domain: "bulkadded2.mocksite4.com"},
+			},
+		},
+		// Replace a single Origin
+		os.Replacement{
+			Index: 2,
+			Value: os.Origin{Origin: "44.33.22.11", Port: 80, SSL: false},
+		},
+		// Bulk replace Origins
+		os.Replacement{
+			Index: 0, // Ignored
+			Value: os.OriginList{
+				os.Origin{Origin: "44.33.22.11", Port: 80, SSL: false},
+				os.Origin{Origin: "55.44.33.22", Port: 443, SSL: true},
+			},
+		},
+		// Remove a single CacheRule
+		os.Removal{
+			Index: 8,
+			Path:  os.PathCaching,
 		},
 	}
 


### PR DESCRIPTION
The CDN "services" resource accepts [PATCH updates in JSON Patch notation]((http://docs.rackspace.com/cdn/api/v1.0/cdn-devguide/content/PATCH_patchService__services__service_id__servicesOperations.html)). This will change the types to constrain what users can send to valid patches. I have an implementation stubbed out on the [Go playground](https://play.golang.org/p/b-TBVZIfuY), so this will apply it to Gophercloud proper.

 - [x] Bring in the Path type.
 - [x] Bring in the value interface.
  - [x] Implement value for Domains.
  - [x] Implement value for Origins.
  - [x] Implement value for CacheRules.
 - [x] Bring in the Patch interface.
  - [x] Addition
  - [x] Removal
  - [x] Replacement
 - [x] Accept a Patch array in Update.
 - [x] Get rid of the old UpdateOpts code.
 - [x] Extend Addition to support [either an exact index or "-" to append](https://tools.ietf.org/html/rfc6902#section-4.1).
 - [x] Extend the Patches to handle bulk operations.
 - [x] Update unit and acceptance tests to match.
 - [x] Support `/name` replacement.
 - [x] Support bulk removal.