### PR TITLE
Add UpdateOpts type for consistency

### DIFF
--- a/acceptance/rackspace/cdn/v1/service_test.go
+++ b/acceptance/rackspace/cdn/v1/service_test.go
@@ -16,7 +16,7 @@ func TestService(t *testing.T) {
 	client := newClient(t)
 
 	t.Log("Creating Service")
-	loc := testServiceCreate(t, client)
+	loc := testServiceCreate(t, client, "test-site-1")
 	t.Logf("Created service at location: %s", loc)
 
 	defer testServiceDelete(t, client, loc)
@@ -31,17 +31,17 @@ func TestService(t *testing.T) {
 	testServiceList(t, client)
 }
 
-func testServiceCreate(t *testing.T, client *gophercloud.ServiceClient) string {
+func testServiceCreate(t *testing.T, client *gophercloud.ServiceClient, name string) string {
 	createOpts := os.CreateOpts{
-		Name: "gophercloud-test-service",
+		Name: name,
 		Domains: []os.Domain{
 			os.Domain{
-				Domain: "www.gophercloud-test-service.com",
+				Domain: "www." + name + ".com",
 			},
 		},
 		Origins: []os.Origin{
 			os.Origin{
-				Origin: "gophercloud-test-service.com",
+				Origin: name + ".com",
 				Port:   80,
 				SSL:    false,
 			},
@@ -60,7 +60,7 @@ func testServiceGet(t *testing.T, client *gophercloud.ServiceClient, id string) 
 }
 
 func testServiceUpdate(t *testing.T, client *gophercloud.ServiceClient, id string) {
-	opts := []os.Patch{
+	opts := os.UpdateOpts{
 		os.Append{
 			Value: os.Domain{Domain: "newDomain.com", Protocol: "http"},
 		},

--- a/acceptance/rackspace/cdn/v1/serviceasset_test.go
+++ b/acceptance/rackspace/cdn/v1/serviceasset_test.go
@@ -15,7 +15,7 @@ func TestServiceAsset(t *testing.T) {
 	client := newClient(t)
 
 	t.Log("Creating Service")
-	loc := testServiceCreate(t, client)
+	loc := testServiceCreate(t, client, "test-site-2")
 	t.Logf("Created service at location: %s", loc)
 
 	t.Log("Deleting Service Assets")

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -339,12 +339,14 @@ func (r Removal) ToCDNServiceUpdateMap() map[string]interface{} {
 	return result
 }
 
+type UpdateOpts []Patch
+
 // Update accepts a slice of Patch operations (Insertion, Append, Replacement or Removal) and
 // updates an existing CDN service using the values provided. idOrURL can be either the service's
 // URL or its ID. For example, both "96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0" and
 // "https://global.cdn.api.rackspacecloud.com/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
 // are valid options for idOrURL.
-func Update(c *gophercloud.ServiceClient, idOrURL string, patches []Patch) UpdateResult {
+func Update(c *gophercloud.ServiceClient, idOrURL string, opts UpdateOpts) UpdateResult {
 	var url string
 	if strings.Contains(idOrURL, "/") {
 		url = idOrURL
@@ -352,8 +354,8 @@ func Update(c *gophercloud.ServiceClient, idOrURL string, patches []Patch) Updat
 		url = updateURL(c, idOrURL)
 	}
 
-	reqBody := make([]map[string]interface{}, len(patches))
-	for i, patch := range patches {
+	reqBody := make([]map[string]interface{}, len(opts))
+	for i, patch := range opts {
 		reqBody[i] = patch.ToCDNServiceUpdateMap()
 	}
 

--- a/openstack/cdn/v1/services/requests_test.go
+++ b/openstack/cdn/v1/services/requests_test.go
@@ -298,7 +298,7 @@ func TestSuccessfulUpdate(t *testing.T) {
 	HandleUpdateCDNServiceSuccessfully(t)
 
 	expected := "https://www.poppycdn.io/v1.0/services/96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0"
-	ops := []Patch{
+	ops := UpdateOpts{
 		// Append a single Domain
 		Append{Value: Domain{Domain: "appended.mocksite4.com"}},
 		// Insert a single Domain


### PR DESCRIPTION
This PR adds an `UpdateOpts` type (of type `[]Patch`) to the `services` package to stay consistent with the other packages. It also update the unit and acceptance tests to reflect the addition.
There is also a fix for a minor bug in the `serviceasset` acceptance test; create a service was failing because one of the same name already existed (from the tests that creates a service in the `service` acceptance test).