### PR TITLE
Add missing OK Codes for servers.Get

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -230,6 +230,7 @@ func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	_, result.Err = perigee.Request("GET", getURL(client, id), perigee.Options{
 		Results:     &result.Body,
 		MoreHeaders: client.AuthenticatedHeaders(),
+		OkCodes:     []int{200, 203},
 	})
 	return result
 }


### PR DESCRIPTION
Without this OK Codes, for instance when a server is terminated and no longer available, no error is returned even when the request fails with a 404.