### PR TITLE
Fix openstack blockstorage attachments types

### DIFF
--- a/openstack/blockstorage/v1/volumes/fixtures.go
+++ b/openstack/blockstorage/v1/volumes/fixtures.go
@@ -45,8 +45,16 @@ func MockGetResponse(t *testing.T) {
 {
     "volume": {
         "display_name": "vol-001",
-        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
-    }
+        "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+ 				"attachments": [
+					{
+						"device": "/dev/vde",
+						"server_id": "a740d24b-dc5b-4d59-ac75-53971c2920ba",
+						"id": "d6da11e5-2ed3-413e-88d8-b772ba62193d",
+						"volume_id": "d6da11e5-2ed3-413e-88d8-b772ba62193d"
+					}
+				]
+   }
 }
       `)
 	})

--- a/openstack/blockstorage/v1/volumes/fixtures.go
+++ b/openstack/blockstorage/v1/volumes/fixtures.go
@@ -46,14 +46,14 @@ func MockGetResponse(t *testing.T) {
     "volume": {
         "display_name": "vol-001",
         "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
- 				"attachments": [
-					{
-						"device": "/dev/vde",
-						"server_id": "a740d24b-dc5b-4d59-ac75-53971c2920ba",
-						"id": "d6da11e5-2ed3-413e-88d8-b772ba62193d",
-						"volume_id": "d6da11e5-2ed3-413e-88d8-b772ba62193d"
-					}
-				]
+ 	"attachments": [
+	  {
+            "device": "/dev/vde",
+            "server_id": "a740d24b-dc5b-4d59-ac75-53971c2920ba",
+            "id": "d6da11e5-2ed3-413e-88d8-b772ba62193d",
+            "volume_id": "d6da11e5-2ed3-413e-88d8-b772ba62193d"
+          }
+        ]
    }
 }
       `)

--- a/openstack/blockstorage/v1/volumes/requests_test.go
+++ b/openstack/blockstorage/v1/volumes/requests_test.go
@@ -56,6 +56,7 @@ func TestGet(t *testing.T) {
 
 	th.AssertEquals(t, v.Name, "vol-001")
 	th.AssertEquals(t, v.ID, "d32019d3-bc6e-4319-9c1d-6722fc136a22")
+	th.AssertEquals(t, v.Attachments[0]["device"], "/dev/vde")
 }
 
 func TestCreate(t *testing.T) {

--- a/openstack/blockstorage/v1/volumes/results.go
+++ b/openstack/blockstorage/v1/volumes/results.go
@@ -16,7 +16,7 @@ type Volume struct {
 	Name string `mapstructure:"display_name"`
 
 	// Instances onto which the volume is attached.
-	Attachments []string `mapstructure:"attachments"`
+	Attachments []map[string]string `mapstructure:"attachments"`
 
 	// This parameter is no longer used.
 	AvailabilityZone string `mapstructure:"availability_zone"`


### PR DESCRIPTION
This commit changes the blockstorage attachments type from
a slice of strings to a slice of string maps to better suit the
actual returned results.