### PR TITLE
fix ListByServer URL and unit test

### DIFF
--- a/openstack/compute/v2/extensions/secgroups/fixtures.go
+++ b/openstack/compute/v2/extensions/secgroups/fixtures.go
@@ -38,7 +38,7 @@ func mockListGroupsResponse(t *testing.T) {
 }
 
 func mockListGroupsByServerResponse(t *testing.T, serverID string) {
-	url := fmt.Sprintf("%s/servers/%s%s", rootPath, serverID, rootPath)
+	url := fmt.Sprintf("/servers/%s%s", serverID, rootPath)
 	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)

--- a/openstack/compute/v2/extensions/secgroups/urls.go
+++ b/openstack/compute/v2/extensions/secgroups/urls.go
@@ -16,7 +16,7 @@ func rootURL(c *gophercloud.ServiceClient) string {
 }
 
 func listByServerURL(c *gophercloud.ServiceClient, serverID string) string {
-	return c.ServiceURL(secgrouppath, "servers", serverID, secgrouppath)
+	return c.ServiceURL("servers", serverID, secgrouppath)
 }
 
 func rootRuleURL(c *gophercloud.ServiceClient) string {


### PR DESCRIPTION
This PR fixes the URL for the ListByServer function for the `secgroups` package.