### PR TITLE
Use client.Request instead of perigee

### DIFF
--- a/openstack/cdn/v1/base/requests.go
+++ b/openstack/cdn/v1/base/requests.go
@@ -1,19 +1,14 @@
 package base
 
-import (
-	"github.com/rackspace/gophercloud"
-
-	"github.com/racker/perigee"
-)
+import "github.com/rackspace/gophercloud"
 
 // Get retrieves the home document, allowing the user to discover the
 // entire API.
 func Get(c *gophercloud.ServiceClient) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -21,10 +16,9 @@ func Get(c *gophercloud.ServiceClient) GetResult {
 // Ping retrieves a ping to the server.
 func Ping(c *gophercloud.ServiceClient) PingResult {
 	var res PingResult
-	_, res.Err = perigee.Request("GET", pingURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
+	_, res.Err = c.Request("GET", pingURL(c), gophercloud.RequestOpts{
 		OkCodes:     []int{204},
-		OmitAccept:  true,
+		MoreHeaders: map[string]string{"Accept": ""},
 	})
 	return res
 }

--- a/openstack/cdn/v1/flavors/requests.go
+++ b/openstack/cdn/v1/flavors/requests.go
@@ -1,7 +1,6 @@
 package flavors
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -18,10 +17,9 @@ func List(c *gophercloud.ServiceClient) pagination.Pager {
 // Get retrieves a specific flavor based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/cdn/v1/serviceassets/requests.go
+++ b/openstack/cdn/v1/serviceassets/requests.go
@@ -3,7 +3,6 @@ package serviceassets
 import (
 	"strings"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 )
 
@@ -44,9 +43,8 @@ func Delete(c *gophercloud.ServiceClient, idOrURL string, opts DeleteOptsBuilder
 	}
 
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -181,7 +181,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 		JSONBody: &reqBody,
 		OkCodes:  []int{202},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -361,7 +361,7 @@ func Update(c *gophercloud.ServiceClient, idOrURL string, opts UpdateOpts) Updat
 		OkCodes:  []int{202},
 	})
 	var result UpdateResult
-	result.Header = resp.HttpResponse.Header
+	result.Header = resp.Header
 	result.Err = err
 	return result
 }

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -178,10 +177,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 	}
 
 	// Send request to API
-	resp, err := perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	resp, err := c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 	res.Header = resp.HttpResponse.Header
 	res.Err = err
@@ -358,10 +356,9 @@ func Update(c *gophercloud.ServiceClient, idOrURL string, opts UpdateOpts) Updat
 		reqBody[i] = patch.ToCDNServiceUpdateMap()
 	}
 
-	resp, err := perigee.Request("PATCH", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	resp, err := c.Request("PATCH", url, gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 	var result UpdateResult
 	result.Header = resp.HttpResponse.Header

--- a/openstack/cdn/v1/services/requests.go
+++ b/openstack/cdn/v1/services/requests.go
@@ -201,10 +201,9 @@ func Get(c *gophercloud.ServiceClient, idOrURL string) GetResult {
 	}
 
 	var res GetResult
-	_, res.Err = perigee.Request("GET", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", url, gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -383,9 +382,8 @@ func Delete(c *gophercloud.ServiceClient, idOrURL string) DeleteResult {
 	}
 
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -68,7 +68,7 @@ func Authenticate(client *gophercloud.ProviderClient, options gophercloud.AuthOp
 		&utils.Version{ID: v30, Priority: 30, Suffix: "/v3/"},
 	}
 
-	chosen, endpoint, err := utils.ChooseVersion(client.IdentityBase, client.IdentityEndpoint, versions)
+	chosen, endpoint, err := utils.ChooseVersion(client, versions)
 	if err != nil {
 		return err
 	}

--- a/openstack/common/extensions/requests.go
+++ b/openstack/common/extensions/requests.go
@@ -1,7 +1,6 @@
 package extensions
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -9,10 +8,9 @@ import (
 // Get retrieves information for a specific extension using its alias.
 func Get(c *gophercloud.ServiceClient, alias string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", ExtensionURL(c, alias), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", ExtensionURL(c, alias), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
-
-	"github.com/racker/perigee"
 )
 
 // SourceType represents the type of medium being used to create the volume.
@@ -101,11 +99,10 @@ func Create(client *gophercloud.ServiceClient, opts servers.CreateOptsBuilder) s
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", createURL(client), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 202},
+	_, res.Err = client.Request("POST", createURL(client), gophercloud.RequestOpts{
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 202},
 	})
 	return res
 }

--- a/openstack/compute/v2/extensions/defsecrules/requests.go
+++ b/openstack/compute/v2/extensions/defsecrules/requests.go
@@ -3,8 +3,6 @@ package defsecrules
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -88,10 +86,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var result GetResult
 
-	_, result.Err = perigee.Request("GET", resourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("GET", resourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -101,9 +98,8 @@ func Get(client *gophercloud.ServiceClient, id string) GetResult {
 func Delete(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
 	var result gophercloud.ErrResult
 
-	_, result.Err = perigee.Request("DELETE", resourceURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, result.Err = client.Request("DELETE", resourceURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 
 	return result

--- a/openstack/compute/v2/extensions/defsecrules/requests.go
+++ b/openstack/compute/v2/extensions/defsecrules/requests.go
@@ -75,11 +75,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return result
 	}
 
-	_, result.Err = perigee.Request("POST", rootURL(client), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     &reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", rootURL(client), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return result

--- a/openstack/compute/v2/extensions/floatingip/requests.go
+++ b/openstack/compute/v2/extensions/floatingip/requests.go
@@ -3,7 +3,6 @@ package floatingip
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -46,11 +45,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", createURL(client), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("POST", createURL(client), gophercloud.RequestOpts{
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -58,10 +56,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 // Get returns data about a previously created FloatingIP.
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("GET", getURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -69,9 +66,8 @@ func Get(client *gophercloud.ServiceClient, id string) GetResult {
 // Delete requests the deletion of a previous allocated FloatingIP.
 func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("DELETE", deleteURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }
@@ -86,10 +82,9 @@ func Associate(client *gophercloud.ServiceClient, serverId, fip string) Associat
 	addFloatingIp["address"] = fip
 	reqBody := map[string]interface{}{"addFloatingIp": addFloatingIp}
 
-	_, res.Err = perigee.Request("POST", associateURL(client, serverId), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", associateURL(client, serverId), gophercloud.RequestOpts{
+		JSONBody: reqBody,
+		OkCodes:  []int{202},
 	})
 	return res
 }
@@ -102,10 +97,9 @@ func Disassociate(client *gophercloud.ServiceClient, serverId, fip string) Disas
 	removeFloatingIp["address"] = fip
 	reqBody := map[string]interface{}{"removeFloatingIp": removeFloatingIp}
 
-	_, res.Err = perigee.Request("POST", disassociateURL(client, serverId), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", disassociateURL(client, serverId), gophercloud.RequestOpts{
+		JSONBody: reqBody,
+		OkCodes:  []int{202},
 	})
 	return res
 }

--- a/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/openstack/compute/v2/extensions/keypairs/requests.go
@@ -82,11 +82,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", createURL(client), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("POST", createURL(client), gophercloud.RequestOpts{
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/compute/v2/extensions/keypairs/requests.go
+++ b/openstack/compute/v2/extensions/keypairs/requests.go
@@ -3,7 +3,6 @@ package keypairs
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/pagination"
@@ -93,10 +92,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 // Get returns public data about a previously uploaded KeyPair.
 func Get(client *gophercloud.ServiceClient, name string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(client, name), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("GET", getURL(client, name), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -104,9 +102,8 @@ func Get(client *gophercloud.ServiceClient, name string) GetResult {
 // Delete requests the deletion of a previous stored KeyPair from the server.
 func Delete(client *gophercloud.ServiceClient, name string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(client, name), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("DELETE", deleteURL(client, name), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/openstack/compute/v2/extensions/secgroups/requests.go
@@ -3,8 +3,6 @@ package secgroups
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -125,11 +123,10 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 		return result
 	}
 
-	_, result.Err = perigee.Request("PUT", resourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     &reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("PUT", resourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -139,10 +136,9 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var result GetResult
 
-	_, result.Err = perigee.Request("GET", resourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("GET", resourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -152,9 +148,8 @@ func Get(client *gophercloud.ServiceClient, id string) GetResult {
 func Delete(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
 	var result gophercloud.ErrResult
 
-	_, result.Err = perigee.Request("DELETE", resourceURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, result.Err = client.Request("DELETE", resourceURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return result
@@ -252,9 +247,8 @@ func CreateRule(client *gophercloud.ServiceClient, opts CreateRuleOptsBuilder) C
 func DeleteRule(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
 	var result gophercloud.ErrResult
 
-	_, result.Err = perigee.Request("DELETE", resourceRuleURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, result.Err = client.Request("DELETE", resourceRuleURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return result
@@ -271,11 +265,10 @@ func actionMap(prefix, groupName string) map[string]map[string]string {
 func AddServerToGroup(client *gophercloud.ServiceClient, serverID, groupName string) gophercloud.ErrResult {
 	var result gophercloud.ErrResult
 
-	_, result.Err = perigee.Request("POST", serverActionURL(client, serverID), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     actionMap("add", groupName),
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, result.Err = client.Request("POST", serverActionURL(client, serverID), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     actionMap("add", groupName),
+		OkCodes:      []int{202},
 	})
 
 	return result
@@ -285,11 +278,10 @@ func AddServerToGroup(client *gophercloud.ServiceClient, serverID, groupName str
 func RemoveServerFromGroup(client *gophercloud.ServiceClient, serverID, groupName string) gophercloud.ErrResult {
 	var result gophercloud.ErrResult
 
-	_, result.Err = perigee.Request("POST", serverActionURL(client, serverID), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     actionMap("remove", groupName),
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, result.Err = client.Request("POST", serverActionURL(client, serverID), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     actionMap("remove", groupName),
+		OkCodes:      []int{202},
 	})
 
 	return result

--- a/openstack/compute/v2/extensions/secgroups/requests.go
+++ b/openstack/compute/v2/extensions/secgroups/requests.go
@@ -80,11 +80,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return result
 	}
 
-	_, result.Err = perigee.Request("POST", rootURL(client), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     &reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", rootURL(client), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -240,11 +239,10 @@ func CreateRule(client *gophercloud.ServiceClient, opts CreateRuleOptsBuilder) C
 		return result
 	}
 
-	_, result.Err = perigee.Request("POST", rootRuleURL(client), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     &reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", rootRuleURL(client), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return result

--- a/openstack/compute/v2/extensions/startstop/requests.go
+++ b/openstack/compute/v2/extensions/startstop/requests.go
@@ -1,9 +1,6 @@
 package startstop
 
-import (
-	"github.com/racker/perigee"
-	"github.com/rackspace/gophercloud"
-)
+import "github.com/rackspace/gophercloud"
 
 func actionURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "action")
@@ -15,10 +12,9 @@ func Start(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
 
 	reqBody := map[string]interface{}{"os-start": nil}
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -30,10 +26,9 @@ func Stop(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
 
 	reqBody := map[string]interface{}{"os-stop": nil}
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res

--- a/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -3,7 +3,6 @@ package volumeattach
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -55,11 +54,10 @@ func Create(client *gophercloud.ServiceClient, serverId string, opts CreateOptsB
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", createURL(client, serverId), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("POST", createURL(client, serverId), gophercloud.RequestOpts{
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -67,10 +65,9 @@ func Create(client *gophercloud.ServiceClient, serverId string, opts CreateOptsB
 // Get returns public data about a previously created VolumeAttachment.
 func Get(client *gophercloud.ServiceClient, serverId, aId string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(client, serverId, aId), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("GET", getURL(client, serverId, aId), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -78,9 +75,8 @@ func Get(client *gophercloud.ServiceClient, serverId, aId string) GetResult {
 // Delete requests the deletion of a previous stored VolumeAttachment from the server.
 func Delete(client *gophercloud.ServiceClient, serverId, aId string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(client, serverId, aId), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("DELETE", deleteURL(client, serverId, aId), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/openstack/compute/v2/flavors/requests.go
+++ b/openstack/compute/v2/flavors/requests.go
@@ -1,7 +1,6 @@
 package flavors
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -64,9 +63,8 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 // Use ExtractFlavor to convert its result into a Flavor.
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var gr GetResult
-	gr.Err = perigee.Get(getURL(client, id), perigee.Options{
-		Results:     &gr.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, gr.Err = client.Request("GET", getURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &gr.Body,
 	})
 	return gr
 }

--- a/openstack/compute/v2/images/requests.go
+++ b/openstack/compute/v2/images/requests.go
@@ -3,8 +3,6 @@ package images
 import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
@@ -62,10 +60,9 @@ func ListDetail(client *gophercloud.ServiceClient, opts ListOptsBuilder) paginat
 // Use ExtractImage() to interpret the result as an openstack Image.
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var result GetResult
-	_, result.Err = perigee.Request("GET", getURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &result.Body,
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("GET", getURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 	return result
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -217,11 +217,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", listURL(client), perigee.Options{
-		Results:     &res.Body,
-		ReqBody:     reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", listURL(client), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		JSONBody:     reqBody,
+		OkCodes:      []int{202},
 	})
 	return res
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -228,9 +227,8 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 // Delete requests that a server previously provisioned be removed from your account.
 func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = client.Request("DELETE", deleteURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }
@@ -238,10 +236,9 @@ func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 // Get requests details on a single server, by ID.
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var result GetResult
-	_, result.Err = perigee.Request("GET", getURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 203},
+	_, result.Err = client.Request("GET", getURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200, 203},
 	})
 	return result
 }
@@ -283,10 +280,9 @@ func (opts UpdateOpts) ToServerUpdateMap() map[string]interface{} {
 // Update requests that various attributes of the indicated server be changed.
 func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) UpdateResult {
 	var result UpdateResult
-	_, result.Err = perigee.Request("PUT", updateURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     opts.ToServerUpdateMap(),
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, result.Err = client.Request("PUT", updateURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     opts.ToServerUpdateMap(),
 	})
 	return result
 }
@@ -303,10 +299,9 @@ func ChangeAdminPassword(client *gophercloud.ServiceClient, id, newPassword stri
 
 	var res ActionResult
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody:     req,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: req,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -372,14 +367,13 @@ func Reboot(client *gophercloud.ServiceClient, id string, how RebootMethod) Acti
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody: struct {
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: struct {
 			C map[string]string `json:"reboot"`
 		}{
 			map[string]string{"type": string(how)},
 		},
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+		OkCodes: []int{202},
 	})
 
 	return res
@@ -474,11 +468,10 @@ func Rebuild(client *gophercloud.ServiceClient, id string, opts RebuildOptsBuild
 		return result
 	}
 
-	_, result.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody:     &reqBody,
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, result.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{202},
 	})
 
 	return result
@@ -521,10 +514,9 @@ func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody:     reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -535,10 +527,9 @@ func Resize(client *gophercloud.ServiceClient, id string, opts ResizeOptsBuilder
 func ConfirmResize(client *gophercloud.ServiceClient, id string) ActionResult {
 	var res ActionResult
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody:     map[string]interface{}{"confirmResize": nil},
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: map[string]interface{}{"confirmResize": nil},
+		OkCodes:  []int{204},
 	})
 
 	return res
@@ -549,10 +540,9 @@ func ConfirmResize(client *gophercloud.ServiceClient, id string) ActionResult {
 func RevertResize(client *gophercloud.ServiceClient, id string) ActionResult {
 	var res ActionResult
 
-	_, res.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		ReqBody:     map[string]interface{}{"revertResize": nil},
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONBody: map[string]interface{}{"revertResize": nil},
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -596,11 +586,10 @@ func Rescue(client *gophercloud.ServiceClient, id string, opts RescueOptsBuilder
 		return result
 	}
 
-	_, result.Err = perigee.Request("POST", actionURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     &reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", actionURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -636,10 +625,9 @@ func ResetMetadata(client *gophercloud.ServiceClient, id string, opts ResetMetad
 		res.Err = err
 		return res
 	}
-	_, res.Err = perigee.Request("PUT", metadataURL(client, id), perigee.Options{
-		ReqBody:     metadata,
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("PUT", metadataURL(client, id), gophercloud.RequestOpts{
+		JSONBody:     metadata,
+		JSONResponse: &res.Body,
 	})
 	return res
 }
@@ -647,9 +635,8 @@ func ResetMetadata(client *gophercloud.ServiceClient, id string, opts ResetMetad
 // Metadata requests all the metadata for the given server ID.
 func Metadata(client *gophercloud.ServiceClient, id string) GetMetadataResult {
 	var res GetMetadataResult
-	_, res.Err = perigee.Request("GET", metadataURL(client, id), perigee.Options{
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("GET", metadataURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
 	})
 	return res
 }
@@ -670,10 +657,9 @@ func UpdateMetadata(client *gophercloud.ServiceClient, id string, opts UpdateMet
 		res.Err = err
 		return res
 	}
-	_, res.Err = perigee.Request("POST", metadataURL(client, id), perigee.Options{
-		ReqBody:     metadata,
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("POST", metadataURL(client, id), gophercloud.RequestOpts{
+		JSONBody:     metadata,
+		JSONResponse: &res.Body,
 	})
 	return res
 }
@@ -709,10 +695,9 @@ func CreateMetadatum(client *gophercloud.ServiceClient, id string, opts Metadatu
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", metadatumURL(client, id, key), perigee.Options{
-		ReqBody:     metadatum,
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("PUT", metadatumURL(client, id, key), gophercloud.RequestOpts{
+		JSONBody:     metadatum,
+		JSONResponse: &res.Body,
 	})
 	return res
 }
@@ -720,9 +705,8 @@ func CreateMetadatum(client *gophercloud.ServiceClient, id string, opts Metadatu
 // Metadatum requests the key-value pair with the given key for the given server ID.
 func Metadatum(client *gophercloud.ServiceClient, id, key string) GetMetadatumResult {
 	var res GetMetadatumResult
-	_, res.Err = perigee.Request("GET", metadatumURL(client, id, key), perigee.Options{
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("GET", metadatumURL(client, id, key), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
 	})
 	return res
 }
@@ -730,9 +714,8 @@ func Metadatum(client *gophercloud.ServiceClient, id, key string) GetMetadatumRe
 // DeleteMetadatum will delete the key-value pair with the given key for the given server ID.
 func DeleteMetadatum(client *gophercloud.ServiceClient, id, key string) DeleteMetadatumResult {
 	var res DeleteMetadatumResult
-	_, res.Err = perigee.Request("DELETE", metadatumURL(client, id, key), perigee.Options{
-		Results:     &res.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
+	_, res.Err = client.Request("DELETE", metadatumURL(client, id, key), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
 	})
 	return res
 }

--- a/openstack/identity/v2/extensions/admin/roles/requests.go
+++ b/openstack/identity/v2/extensions/admin/roles/requests.go
@@ -1,7 +1,6 @@
 package roles
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -21,9 +20,8 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 func AddUserRole(client *gophercloud.ServiceClient, tenantID, userID, roleID string) UserRoleResult {
 	var result UserRoleResult
 
-	_, result.Err = perigee.Request("PUT", userRoleURL(client, tenantID, userID, roleID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 201},
+	_, result.Err = client.Request("PUT", userRoleURL(client, tenantID, userID, roleID), gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
 	})
 
 	return result
@@ -35,9 +33,8 @@ func AddUserRole(client *gophercloud.ServiceClient, tenantID, userID, roleID str
 func DeleteUserRole(client *gophercloud.ServiceClient, tenantID, userID, roleID string) UserRoleResult {
 	var result UserRoleResult
 
-	_, result.Err = perigee.Request("DELETE", userRoleURL(client, tenantID, userID, roleID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, result.Err = client.Request("DELETE", userRoleURL(client, tenantID, userID, roleID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 
 	return result

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -1,9 +1,6 @@
 package tokens
 
-import (
-	"github.com/racker/perigee"
-	"github.com/rackspace/gophercloud"
-)
+import "github.com/rackspace/gophercloud"
 
 // AuthOptionsBuilder describes any argument that may be passed to the Create call.
 type AuthOptionsBuilder interface {
@@ -78,10 +75,10 @@ func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) CreateRe
 	}
 
 	var result CreateResult
-	_, result.Err = perigee.Request("POST", CreateURL(client), perigee.Options{
-		ReqBody: &request,
-		Results: &result.Body,
-		OkCodes: []int{200, 203},
+	_, result.Err = client.Request("POST", CreateURL(client), gophercloud.RequestOpts{
+		JSONBody:     &request,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200, 203},
 	})
 	return result
 }

--- a/openstack/identity/v2/users/requests.go
+++ b/openstack/identity/v2/users/requests.go
@@ -91,11 +91,10 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", rootURL(client), perigee.Options{
-		Results:     &res.Body,
-		ReqBody:     reqBody,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 201},
+	_, res.Err = client.Request("POST", rootURL(client), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		JSONBody:     reqBody,
+		OkCodes:      []int{200, 201},
 	})
 
 	return res

--- a/openstack/identity/v2/users/requests.go
+++ b/openstack/identity/v2/users/requests.go
@@ -3,7 +3,6 @@ package users
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -104,10 +103,9 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 func Get(client *gophercloud.ServiceClient, id string) GetResult {
 	var result GetResult
 
-	_, result.Err = perigee.Request("GET", ResourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("GET", ResourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -148,11 +146,10 @@ func (opts UpdateOpts) ToUserUpdateMap() map[string]interface{} {
 func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) UpdateResult {
 	var result UpdateResult
 
-	_, result.Err = perigee.Request("PUT", ResourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     opts.ToUserUpdateMap(),
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("PUT", ResourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     opts.ToUserUpdateMap(),
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -162,9 +159,8 @@ func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder
 func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 	var result DeleteResult
 
-	_, result.Err = perigee.Request("DELETE", ResourceURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, result.Err = client.Request("DELETE", ResourceURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 
 	return result

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -57,11 +57,10 @@ func Create(client *gophercloud.ServiceClient, opts EndpointOpts) CreateResult {
 	reqBody.Endpoint.Region = gophercloud.MaybeString(opts.Region)
 
 	var result CreateResult
-	_, result.Err = perigee.Request("POST", listURL(client), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &result.Body,
-		OkCodes:     []int{201},
+	_, result.Err = client.Request("POST", listURL(client), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{201},
 	})
 	return result
 }

--- a/openstack/identity/v3/endpoints/requests.go
+++ b/openstack/identity/v3/endpoints/requests.go
@@ -1,7 +1,6 @@
 package endpoints
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -112,11 +111,10 @@ func Update(client *gophercloud.ServiceClient, endpointID string, opts EndpointO
 	reqBody.Endpoint.ServiceID = gophercloud.MaybeString(opts.ServiceID)
 
 	var result UpdateResult
-	_, result.Err = perigee.Request("PATCH", endpointURL(client, endpointID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &result.Body,
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("PATCH", endpointURL(client, endpointID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 	return result
 }
@@ -124,9 +122,8 @@ func Update(client *gophercloud.ServiceClient, endpointID string, opts EndpointO
 // Delete removes an endpoint from the service catalog.
 func Delete(client *gophercloud.ServiceClient, endpointID string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", endpointURL(client, endpointID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = client.Request("DELETE", endpointURL(client, endpointID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/identity/v3/services/requests.go
+++ b/openstack/identity/v3/services/requests.go
@@ -19,11 +19,10 @@ func Create(client *gophercloud.ServiceClient, serviceType string) CreateResult 
 	req := request{Type: serviceType}
 
 	var result CreateResult
-	_, result.Err = perigee.Request("POST", listURL(client), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &req,
-		Results:     &result.Body,
-		OkCodes:     []int{201},
+	_, result.Err = client.Request("POST", listURL(client), gophercloud.RequestOpts{
+		JSONBody:     &req,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{201},
 	})
 	return result
 }

--- a/openstack/identity/v3/services/requests.go
+++ b/openstack/identity/v3/services/requests.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -52,10 +51,9 @@ func List(client *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
 // Get returns additional information about a service, given its ID.
 func Get(client *gophercloud.ServiceClient, serviceID string) GetResult {
 	var result GetResult
-	_, result.Err = perigee.Request("GET", serviceURL(client, serviceID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &result.Body,
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("GET", serviceURL(client, serviceID), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 	return result
 }
@@ -69,11 +67,10 @@ func Update(client *gophercloud.ServiceClient, serviceID string, serviceType str
 	req := request{Type: serviceType}
 
 	var result UpdateResult
-	_, result.Err = perigee.Request("PATCH", serviceURL(client, serviceID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &req,
-		Results:     &result.Body,
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("PATCH", serviceURL(client, serviceID), gophercloud.RequestOpts{
+		JSONBody:     &req,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 	return result
 }
@@ -82,9 +79,8 @@ func Update(client *gophercloud.ServiceClient, serviceID string, serviceType str
 // It either deletes all associated endpoints, or fails until all endpoints are deleted.
 func Delete(client *gophercloud.ServiceClient, serviceID string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", serviceURL(client, serviceID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = client.Request("DELETE", serviceURL(client, serviceID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -234,10 +234,10 @@ func Create(c *gophercloud.ServiceClient, options gophercloud.AuthOptions, scope
 
 	var result CreateResult
 	var response *perigee.Response
-	response, result.Err = perigee.Request("POST", tokenURL(c), perigee.Options{
-		ReqBody: &req,
-		Results: &result.Body,
-		OkCodes: []int{201},
+	response, result.Err = c.Request("POST", tokenURL(c), gophercloud.RequestOpts{
+		JSONBody:     &req,
+		JSONResponse: &result.Body,
+		OkCodes:      []int{201},
 	})
 	if result.Err != nil {
 		return result
@@ -250,10 +250,10 @@ func Create(c *gophercloud.ServiceClient, options gophercloud.AuthOptions, scope
 func Get(c *gophercloud.ServiceClient, token string) GetResult {
 	var result GetResult
 	var response *perigee.Response
-	response, result.Err = perigee.Request("GET", tokenURL(c), perigee.Options{
-		MoreHeaders: subjectTokenHeaders(c, token),
-		Results:     &result.Body,
-		OkCodes:     []int{200, 203},
+	response, result.Err = c.Request("GET", tokenURL(c), gophercloud.RequestOpts{
+		MoreHeaders:  subjectTokenHeaders(c, token),
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200, 203},
 	})
 	if result.Err != nil {
 		return result
@@ -264,7 +264,7 @@ func Get(c *gophercloud.ServiceClient, token string) GetResult {
 
 // Validate determines if a specified token is valid or not.
 func Validate(c *gophercloud.ServiceClient, token string) (bool, error) {
-	response, err := perigee.Request("HEAD", tokenURL(c), perigee.Options{
+	response, err := c.Request("HEAD", tokenURL(c), gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(c, token),
 		OkCodes:     []int{204, 404},
 	})
@@ -278,7 +278,7 @@ func Validate(c *gophercloud.ServiceClient, token string) (bool, error) {
 // Revoke immediately makes specified token invalid.
 func Revoke(c *gophercloud.ServiceClient, token string) RevokeResult {
 	var res RevokeResult
-	_, res.Err = perigee.Request("DELETE", tokenURL(c), perigee.Options{
+	_, res.Err = c.Request("DELETE", tokenURL(c), gophercloud.RequestOpts{
 		MoreHeaders: subjectTokenHeaders(c, token),
 		OkCodes:     []int{204},
 	})

--- a/openstack/identity/v3/tokens/requests.go
+++ b/openstack/identity/v3/tokens/requests.go
@@ -1,7 +1,8 @@
 package tokens
 
 import (
-	"github.com/racker/perigee"
+	"net/http"
+
 	"github.com/rackspace/gophercloud"
 )
 
@@ -233,7 +234,7 @@ func Create(c *gophercloud.ServiceClient, options gophercloud.AuthOptions, scope
 	}
 
 	var result CreateResult
-	var response *perigee.Response
+	var response *http.Response
 	response, result.Err = c.Request("POST", tokenURL(c), gophercloud.RequestOpts{
 		JSONBody:     &req,
 		JSONResponse: &result.Body,
@@ -242,14 +243,14 @@ func Create(c *gophercloud.ServiceClient, options gophercloud.AuthOptions, scope
 	if result.Err != nil {
 		return result
 	}
-	result.Header = response.HttpResponse.Header
+	result.Header = response.Header
 	return result
 }
 
 // Get validates and retrieves information about another token.
 func Get(c *gophercloud.ServiceClient, token string) GetResult {
 	var result GetResult
-	var response *perigee.Response
+	var response *http.Response
 	response, result.Err = c.Request("GET", tokenURL(c), gophercloud.RequestOpts{
 		MoreHeaders:  subjectTokenHeaders(c, token),
 		JSONResponse: &result.Body,
@@ -258,7 +259,7 @@ func Get(c *gophercloud.ServiceClient, token string) GetResult {
 	if result.Err != nil {
 		return result
 	}
-	result.Header = response.HttpResponse.Header
+	result.Header = response.Header
 	return result
 }
 

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -109,11 +109,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	}}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/layer3/floatingips/requests.go
+++ b/openstack/networking/v2/extensions/layer3/floatingips/requests.go
@@ -3,7 +3,6 @@ package floatingips
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -121,10 +120,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular floating IP resource based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -161,11 +159,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 
 	// Send request to API
 	var res UpdateResult
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -176,9 +173,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // internal ports.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -82,11 +82,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	}
 
 	var res CreateResult
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -3,7 +3,6 @@ package routers
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -93,10 +92,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular router based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -135,11 +133,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 
 	// Send request to API
 	var res UpdateResult
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -148,9 +145,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // Delete will permanently delete a particular router based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }
@@ -201,11 +197,10 @@ func AddInterface(c *gophercloud.ServiceClient, id string, opts InterfaceOpts) I
 
 	body := request{SubnetID: opts.SubnetID, PortID: opts.PortID}
 
-	_, res.Err = perigee.Request("PUT", addInterfaceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &body,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", addInterfaceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &body,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -234,11 +229,10 @@ func RemoveInterface(c *gophercloud.ServiceClient, id string, opts InterfaceOpts
 
 	body := request{SubnetID: opts.SubnetID, PortID: opts.PortID}
 
-	_, res.Err = perigee.Request("PUT", removeInterfaceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &body,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", removeInterfaceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &body,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/lbaas/members/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/members/requests.go
@@ -80,11 +80,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	}}
 
 	var res CreateResult
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/members/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/members/requests.go
@@ -1,7 +1,6 @@
 package members
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -91,10 +90,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular pool member based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -118,11 +116,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 
 	// Send request to API
 	var res UpdateResult
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -130,9 +127,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // Delete will permanently delete a particular member based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/monitors/requests.go
@@ -177,11 +177,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		AdminStateUp:  opts.AdminStateUp,
 	}}
 
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/lbaas/monitors/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/monitors/requests.go
@@ -3,7 +3,6 @@ package monitors
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -189,10 +188,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular health monitor based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -260,11 +258,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 		AdminStateUp:  opts.AdminStateUp,
 	}}
 
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 202},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 202},
 	})
 
 	return res
@@ -273,9 +270,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // Delete will permanently delete a particular monitor based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -1,7 +1,6 @@
 package pools
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -111,10 +110,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular pool based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -147,11 +145,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 
 	// Send request to API
 	var res UpdateResult
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -159,9 +156,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // Delete will permanently delete a particular pool based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }
@@ -182,11 +178,10 @@ func AssociateMonitor(c *gophercloud.ServiceClient, poolID, monitorID string) As
 	reqBody := request{hm{ID: monitorID}}
 
 	var res AssociateResult
-	_, res.Err = perigee.Request("POST", associateURL(c, poolID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", associateURL(c, poolID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }
@@ -196,9 +191,8 @@ func AssociateMonitor(c *gophercloud.ServiceClient, poolID, monitorID string) As
 // check for the health of the members of the pool.
 func DisassociateMonitor(c *gophercloud.ServiceClient, poolID, monitorID string) AssociateResult {
 	var res AssociateResult
-	_, res.Err = perigee.Request("DELETE", disassociateURL(c, poolID, monitorID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", disassociateURL(c, poolID, monitorID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -100,11 +100,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	}}
 
 	var res CreateResult
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/vips/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/requests.go
@@ -3,7 +3,6 @@ package vips
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -191,10 +190,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular virtual IP based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -251,11 +249,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 	}
 
 	var res UpdateResult
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 202},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 202},
 	})
 
 	return res
@@ -264,9 +261,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 // Delete will permanently delete a particular virtual IP based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/lbaas/vips/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/requests.go
@@ -179,11 +179,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		reqBody.VirtualIP.Persistence = opts.Persistence
 	}
 
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -3,7 +3,6 @@ package groups
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -87,10 +86,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular security group based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -98,9 +96,8 @@ func Get(c *gophercloud.ServiceClient, id string) GetResult {
 // Delete will permanently delete a particular security group based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -75,11 +75,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Description: opts.Description,
 	}}
 
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -151,11 +151,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		RemoteIPPrefix: opts.RemoteIPPrefix,
 	}}
 
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -163,10 +162,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 // Get retrieves a particular security group based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -174,9 +172,8 @@ func Get(c *gophercloud.ServiceClient, id string) GetResult {
 // Delete will permanently delete a particular security group based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -138,11 +138,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }

--- a/openstack/networking/v2/networks/requests.go
+++ b/openstack/networking/v2/networks/requests.go
@@ -3,8 +3,6 @@ package networks
 import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // AdminState gives users a solid type to work with for create and update
@@ -81,10 +79,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 // Get retrieves a specific network based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -187,11 +184,10 @@ func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuild
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("PUT", updateURL(c, networkID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201},
+	_, res.Err = c.Request("PUT", updateURL(c, networkID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201},
 	})
 
 	return res
@@ -200,9 +196,8 @@ func Update(c *gophercloud.ServiceClient, networkID string, opts UpdateOptsBuild
 // Delete accepts a unique ID and deletes the network associated with it.
 func Delete(c *gophercloud.ServiceClient, networkID string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, networkID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, networkID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -159,11 +159,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 	}
 
 	// Response
-	_, res.Err = perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/ports/requests.go
+++ b/openstack/networking/v2/ports/requests.go
@@ -3,8 +3,6 @@ package ports
 import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // AdminState gives users a solid type to work with for create and update
@@ -81,10 +79,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 // Get retrieves a specific port based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -223,11 +220,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) Upd
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", updateURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201},
+	_, res.Err = c.Request("PUT", updateURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201},
 	})
 	return res
 }
@@ -235,9 +231,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) Upd
 // Delete accepts a unique ID and deletes the port associated with it.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -174,11 +174,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 
 	return res

--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -3,8 +3,6 @@ package subnets
 import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // AdminState gives users a solid type to work with for create and update
@@ -80,10 +78,9 @@ func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 // Get retrieves a specific subnet based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -232,11 +229,10 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) Upd
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", updateURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201},
+	_, res.Err = c.Request("PUT", updateURL(c, id), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201},
 	})
 
 	return res
@@ -245,9 +241,8 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) Upd
 // Delete accepts a unique ID and deletes the subnet associated with it.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/openstack/objectstorage/v1/accounts/requests.go
+++ b/openstack/objectstorage/v1/accounts/requests.go
@@ -1,9 +1,6 @@
 package accounts
 
-import (
-	"github.com/racker/perigee"
-	"github.com/rackspace/gophercloud"
-)
+import "github.com/rackspace/gophercloud"
 
 // GetOptsBuilder allows extensions to add additional headers to the Get
 // request.
@@ -42,7 +39,7 @@ func Get(c *gophercloud.ServiceClient, opts GetOptsBuilder) GetResult {
 		}
 	}
 
-	resp, err := perigee.Request("HEAD", getURL(c), perigee.Options{
+	resp, err := c.Request("HEAD", getURL(c), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})
@@ -96,7 +93,7 @@ func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) UpdateResult {
 		}
 	}
 
-	resp, err := perigee.Request("POST", updateURL(c), perigee.Options{
+	resp, err := c.Request("POST", updateURL(c), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})

--- a/openstack/objectstorage/v1/accounts/requests.go
+++ b/openstack/objectstorage/v1/accounts/requests.go
@@ -43,7 +43,7 @@ func Get(c *gophercloud.ServiceClient, opts GetOptsBuilder) GetResult {
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -80,7 +80,7 @@ func (opts UpdateOpts) ToAccountUpdateMap() (map[string]string, error) {
 // To extract the headers returned, call the Extract method on the UpdateResult.
 func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) UpdateResult {
 	var res UpdateResult
-	h := c.AuthenticatedHeaders()
+	h := make(map[string]string)
 
 	if opts != nil {
 		headers, err := opts.ToAccountUpdateMap()
@@ -97,7 +97,7 @@ func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) UpdateResult {
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -111,11 +110,11 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 		}
 	}
 
-	resp, err := perigee.Request("PUT", createURL(c, containerName), perigee.Options{
+	resp, err := c.Request("PUT", createURL(c, containerName), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -123,9 +122,8 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 // Delete is a function that deletes a container.
 func Delete(c *gophercloud.ServiceClient, containerName string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, containerName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202, 204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, containerName), gophercloud.RequestOpts{
+		OkCodes: []int{202, 204},
 	})
 	return res
 }
@@ -180,11 +178,11 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 		}
 	}
 
-	resp, err := perigee.Request("POST", updateURL(c, containerName), perigee.Options{
+	resp, err := c.Request("POST", updateURL(c, containerName), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{202, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -194,11 +192,10 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 // function.
 func Get(c *gophercloud.ServiceClient, containerName string) GetResult {
 	var res GetResult
-	resp, err := perigee.Request("HEAD", getURL(c, containerName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 204},
+	resp, err := c.Request("HEAD", getURL(c, containerName), gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -136,9 +136,9 @@ func Download(c *gophercloud.ServiceClient, containerName, objectName string, op
 		OkCodes:     []int{200, 304},
 	})
 
-	res.Body = resp.HttpResponse.Body
+	res.Body = resp.Body
 	res.Err = err
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 
 	return res
 }
@@ -279,7 +279,7 @@ func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts C
 		MoreHeaders: h,
 		OkCodes:     []int{201},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -321,7 +321,7 @@ func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts
 	resp, err := c.Request("DELETE", url, gophercloud.RequestOpts{
 		OkCodes: []int{204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -365,7 +365,7 @@ func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts Ge
 	resp, err := c.Request("HEAD", url, gophercloud.RequestOpts{
 		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -422,7 +422,7 @@ func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts
 		MoreHeaders: h,
 		OkCodes:     []int{202},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -131,7 +131,7 @@ func Download(c *gophercloud.ServiceClient, containerName, objectName string, op
 		url += query
 	}
 
-	resp, err := perigee.Request("GET", url, perigee.Options{
+	resp, err := c.Request("GET", url, gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200, 304},
 	})
@@ -275,7 +275,7 @@ func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts C
 	}
 
 	url := copyURL(c, containerName, objectName)
-	resp, err := perigee.Request("COPY", url, perigee.Options{
+	resp, err := c.Request("COPY", url, gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201},
 	})
@@ -318,9 +318,8 @@ func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts
 		url += query
 	}
 
-	resp, err := perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	resp, err := c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	res.Header = resp.HttpResponse.Header
 	res.Err = err
@@ -363,9 +362,8 @@ func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts Ge
 		url += query
 	}
 
-	resp, err := perigee.Request("HEAD", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 204},
+	resp, err := c.Request("HEAD", url, gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
 	})
 	res.Header = resp.HttpResponse.Header
 	res.Err = err
@@ -420,7 +418,7 @@ func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts
 	}
 
 	url := updateURL(c, containerName, objectName)
-	resp, err := perigee.Request("POST", url, perigee.Options{
+	resp, err := c.Request("POST", url, gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{202},
 	})

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/objectstorage/v1/accounts"
 	"github.com/rackspace/gophercloud/pagination"
@@ -193,7 +192,7 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 	var res CreateResult
 
 	url := createURL(c, containerName, objectName)
-	h := c.AuthenticatedHeaders()
+	h := make(map[string]string)
 
 	if opts != nil {
 		headers, query, err := opts.ToObjectCreateParams()
@@ -209,21 +208,14 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 		url += query
 	}
 
-	popts := perigee.Options{
-		ReqBody:     content,
+	ropts := gophercloud.RequestOpts{
+		RawBody:     content,
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202},
 	}
 
-	if contentType, explicit := h["Content-Type"]; explicit {
-		popts.ContentType = contentType
-		delete(h, "Content-Type")
-	} else {
-		popts.OmitContentType = true
-	}
-
-	resp, err := perigee.Request("PUT", url, popts)
-	res.Header = resp.HttpResponse.Header
+	resp, err := c.Request("PUT", url, ropts)
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }

--- a/openstack/orchestration/v1/buildinfo/requests.go
+++ b/openstack/orchestration/v1/buildinfo/requests.go
@@ -1,17 +1,13 @@
 package buildinfo
 
-import (
-	"github.com/racker/perigee"
-	"github.com/rackspace/gophercloud"
-)
+import "github.com/rackspace/gophercloud"
 
 // Get retreives data for the given stack template.
 func Get(c *gophercloud.ServiceClient) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/orchestration/v1/stackevents/requests.go
+++ b/openstack/orchestration/v1/stackevents/requests.go
@@ -1,7 +1,6 @@
 package stackevents
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -10,10 +9,9 @@ import (
 func Find(c *gophercloud.ServiceClient, stackName string) FindResult {
 	var res FindResult
 
-	_, res.Err = perigee.Request("GET", findURL(c, stackName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", findURL(c, stackName), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -199,10 +197,9 @@ func ListResourceEvents(client *gophercloud.ServiceClient, stackName, stackID, r
 // Get retreives data for the given stack resource.
 func Get(c *gophercloud.ServiceClient, stackName, stackID, resourceName, eventID string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, stackName, stackID, resourceName, eventID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, stackName, stackID, resourceName, eventID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/orchestration/v1/stackresources/requests.go
+++ b/openstack/orchestration/v1/stackresources/requests.go
@@ -1,7 +1,6 @@
 package stackresources
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -11,10 +10,9 @@ func Find(c *gophercloud.ServiceClient, stackName string) FindResult {
 	var res FindResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", findURL(c, stackName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", findURL(c, stackName), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -73,10 +71,9 @@ func Get(c *gophercloud.ServiceClient, stackName, stackID, resourceName string) 
 	var res GetResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", getURL(c, stackName, stackID, resourceName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, stackName, stackID, resourceName), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -86,10 +83,9 @@ func Metadata(c *gophercloud.ServiceClient, stackName, stackID, resourceName str
 	var res MetadataResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", metadataURL(c, stackName, stackID, resourceName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", metadataURL(c, stackName, stackID, resourceName), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -110,10 +106,9 @@ func Schema(c *gophercloud.ServiceClient, resourceType string) SchemaResult {
 	var res SchemaResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", schemaURL(c, resourceType), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", schemaURL(c, resourceType), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -123,10 +118,9 @@ func Template(c *gophercloud.ServiceClient, resourceType string) TemplateResult 
 	var res TemplateResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", templateURL(c, resourceType), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", templateURL(c, resourceType), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/orchestration/v1/stacks/requests.go
+++ b/openstack/orchestration/v1/stacks/requests.go
@@ -3,7 +3,6 @@ package stacks
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -113,11 +112,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }
@@ -224,11 +222,10 @@ func Adopt(c *gophercloud.ServiceClient, opts AdoptOptsBuilder) AdoptResult {
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", adoptURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{201},
+	_, res.Err = c.Request("POST", adoptURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{201},
 	})
 	return res
 }
@@ -307,10 +304,9 @@ func Get(c *gophercloud.ServiceClient, stackName, stackID string) GetResult {
 	var res GetResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("GET", getURL(c, stackName, stackID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, stackName, stackID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -393,10 +389,9 @@ func Update(c *gophercloud.ServiceClient, stackName, stackID string, opts Update
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("PUT", updateURL(c, stackName, stackID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", updateURL(c, stackName, stackID), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 	return res
 }
@@ -406,9 +401,8 @@ func Delete(c *gophercloud.ServiceClient, stackName, stackID string) DeleteResul
 	var res DeleteResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, stackName, stackID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, stackName, stackID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }
@@ -504,11 +498,10 @@ func Preview(c *gophercloud.ServiceClient, opts PreviewOptsBuilder) PreviewResul
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", previewURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("POST", previewURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -519,10 +512,9 @@ func Abandon(c *gophercloud.ServiceClient, stackName, stackID string) AbandonRes
 	var res AbandonResult
 
 	// Send request to API
-	_, res.Err = perigee.Request("DELETE", abandonURL(c, stackName, stackID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("DELETE", abandonURL(c, stackName, stackID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/orchestration/v1/stacktemplates/requests.go
+++ b/openstack/orchestration/v1/stacktemplates/requests.go
@@ -3,17 +3,15 @@ package stacktemplates
 import (
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 )
 
 // Get retreives data for the given stack template.
 func Get(c *gophercloud.ServiceClient, stackName, stackID string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, stackName, stackID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, stackName, stackID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -54,11 +52,10 @@ func Validate(c *gophercloud.ServiceClient, opts ValidateOptsBuilder) ValidateRe
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", validateURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("POST", validateURL(c), gophercloud.RequestOpts{
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }

--- a/openstack/utils/choose_version.go
+++ b/openstack/utils/choose_version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/racker/perigee"
+	"github.com/rackspace/gophercloud"
 )
 
 // Version is a supported API version, corresponding to a vN package within the appropriate service.
@@ -59,9 +59,9 @@ func ChooseVersion(identityBase string, identityEndpoint string, recognized []*V
 	}
 
 	var resp response
-	_, err := perigee.Request("GET", identityBase, perigee.Options{
-		Results: &resp,
-		OkCodes: []int{200, 300},
+	_, err := client.Request("GET", identityBase, gophercloud.RequestOpts{
+		JSONResponse: &resp,
+		OkCodes:      []int{200, 300},
 	})
 
 	if err != nil {

--- a/openstack/utils/choose_version.go
+++ b/openstack/utils/choose_version.go
@@ -23,7 +23,7 @@ var goodStatus = map[string]bool{
 // ChooseVersion queries the base endpoint of an API to choose the most recent non-experimental alternative from a service's
 // published versions.
 // It returns the highest-Priority Version among the alternatives that are provided, as well as its corresponding endpoint.
-func ChooseVersion(identityBase string, identityEndpoint string, recognized []*Version) (*Version, string, error) {
+func ChooseVersion(client *gophercloud.ProviderClient, recognized []*Version) (*Version, string, error) {
 	type linkResp struct {
 		Href string `json:"href"`
 		Rel  string `json:"rel"`
@@ -49,7 +49,7 @@ func ChooseVersion(identityBase string, identityEndpoint string, recognized []*V
 		}
 		return endpoint
 	}
-	identityEndpoint = normalize(identityEndpoint)
+	identityEndpoint := normalize(client.IdentityEndpoint)
 
 	// If a full endpoint is specified, check version suffixes for a match first.
 	for _, v := range recognized {
@@ -59,7 +59,7 @@ func ChooseVersion(identityBase string, identityEndpoint string, recognized []*V
 	}
 
 	var resp response
-	_, err := client.Request("GET", identityBase, gophercloud.RequestOpts{
+	_, err := client.Request("GET", client.IdentityBase, gophercloud.RequestOpts{
 		JSONResponse: &resp,
 		OkCodes:      []int{200, 300},
 	})
@@ -88,7 +88,7 @@ func ChooseVersion(identityBase string, identityEndpoint string, recognized []*V
 			// Prefer a version that exactly matches the provided endpoint.
 			if href == identityEndpoint {
 				if href == "" {
-					return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", value.ID, identityBase)
+					return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", value.ID, client.IdentityBase)
 				}
 				return matching, href, nil
 			}
@@ -104,10 +104,10 @@ func ChooseVersion(identityBase string, identityEndpoint string, recognized []*V
 	}
 
 	if highest == nil {
-		return nil, "", fmt.Errorf("No supported version available from endpoint %s", identityBase)
+		return nil, "", fmt.Errorf("No supported version available from endpoint %s", client.IdentityBase)
 	}
 	if endpoint == "" {
-		return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", highest.ID, identityBase)
+		return nil, "", fmt.Errorf("Endpoint missing in version %s response from %s", highest.ID, client.IdentityBase)
 	}
 
 	return highest, endpoint, nil

--- a/openstack/utils/choose_version_test.go
+++ b/openstack/utils/choose_version_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/testhelper"
 )
 
@@ -43,7 +44,11 @@ func TestChooseVersion(t *testing.T) {
 	v2 := &Version{ID: "v2.0", Priority: 2, Suffix: "blarg"}
 	v3 := &Version{ID: "v3.0", Priority: 3, Suffix: "hargl"}
 
-	v, endpoint, err := ChooseVersion(testhelper.Endpoint(), "", []*Version{v2, v3})
+	c := &gophercloud.ProviderClient{
+		IdentityBase:     testhelper.Endpoint(),
+		IdentityEndpoint: "",
+	}
+	v, endpoint, err := ChooseVersion(c, []*Version{v2, v3})
 
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
@@ -67,7 +72,11 @@ func TestChooseVersionOpinionatedLink(t *testing.T) {
 	v2 := &Version{ID: "v2.0", Priority: 2, Suffix: "nope"}
 	v3 := &Version{ID: "v3.0", Priority: 3, Suffix: "northis"}
 
-	v, endpoint, err := ChooseVersion(testhelper.Endpoint(), testhelper.Endpoint()+"v2.0/", []*Version{v2, v3})
+	c := &gophercloud.ProviderClient{
+		IdentityBase:     testhelper.Endpoint(),
+		IdentityEndpoint: testhelper.Endpoint() + "v2.0/",
+	}
+	v, endpoint, err := ChooseVersion(c, []*Version{v2, v3})
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
 	}
@@ -89,7 +98,11 @@ func TestChooseVersionFromSuffix(t *testing.T) {
 	v2 := &Version{ID: "v2.0", Priority: 2, Suffix: "/v2.0/"}
 	v3 := &Version{ID: "v3.0", Priority: 3, Suffix: "/v3.0/"}
 
-	v, endpoint, err := ChooseVersion(testhelper.Endpoint(), testhelper.Endpoint()+"v2.0/", []*Version{v2, v3})
+	c := &gophercloud.ProviderClient{
+		IdentityBase:     testhelper.Endpoint(),
+		IdentityEndpoint: testhelper.Endpoint() + "v2.0/",
+	}
+	v, endpoint, err := ChooseVersion(c, []*Version{v2, v3})
 	if err != nil {
 		t.Fatalf("Unexpected error from ChooseVersion: %v", err)
 	}

--- a/provider_client.go
+++ b/provider_client.go
@@ -59,7 +59,7 @@ type RequestOpts struct {
 
 	// JSONResponse, if provided, will be populated with the contents of the response body parsed as
 	// JSON.
-	JSONResponse *interface{}
+	JSONResponse interface{}
 	// OkCodes contains a list of numeric HTTP status codes that should be interpreted as success. If
 	// the response has a different code, an error will be returned.
 	OkCodes []int

--- a/rackspace/blockstorage/v1/snapshots/delegate.go
+++ b/rackspace/blockstorage/v1/snapshots/delegate.go
@@ -3,8 +3,6 @@ package snapshots
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 
@@ -123,11 +121,10 @@ func Update(c *gophercloud.ServiceClient, snapshotID string, opts UpdateOptsBuil
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("PUT", updateURL(c, snapshotID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201},
+	_, res.Err = c.Request("PUT", updateURL(c, snapshotID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201},
 	})
 
 	return res

--- a/rackspace/blockstorage/v1/snapshots/results.go
+++ b/rackspace/blockstorage/v1/snapshots/results.go
@@ -1,8 +1,6 @@
 package snapshots
 
 import (
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	os "github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
 	"github.com/rackspace/gophercloud/pagination"
@@ -138,7 +136,7 @@ func (snapshot Snapshot) WaitUntilDeleted(c *gophercloud.ServiceClient, timeout 
 		_, err := Get(c, snapshot.ID).Extract()
 
 		// Check for a 404
-		if casted, ok := err.(*perigee.UnexpectedResponseCodeError); ok && casted.Actual == 404 {
+		if casted, ok := err.(*gophercloud.UnexpectedResponseCodeError); ok && casted.Actual == 404 {
 			return true, nil
 		} else if err != nil {
 			return false, err

--- a/rackspace/client.go
+++ b/rackspace/client.go
@@ -59,7 +59,7 @@ func Authenticate(client *gophercloud.ProviderClient, options gophercloud.AuthOp
 		&utils.Version{ID: v20, Priority: 20, Suffix: "/v2.0/"},
 	}
 
-	chosen, endpoint, err := utils.ChooseVersion(client.IdentityBase, client.IdentityEndpoint, versions)
+	chosen, endpoint, err := utils.ChooseVersion(client, versions)
 	if err != nil {
 		return err
 	}

--- a/rackspace/compute/v2/networks/requests.go
+++ b/rackspace/compute/v2/networks/requests.go
@@ -81,11 +81,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", createURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201, 202},
+	_, res.Err = c.Request("POST", createURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201, 202},
 	})
 	return res
 }

--- a/rackspace/compute/v2/networks/requests.go
+++ b/rackspace/compute/v2/networks/requests.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -23,10 +21,9 @@ func List(c *gophercloud.ServiceClient) pagination.Pager {
 // Get retrieves a specific network based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
-	_, res.Err = perigee.Request("GET", getURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", getURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 	return res
 }
@@ -92,9 +89,8 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 // Delete accepts a unique ID and deletes the network associated with it.
 func Delete(c *gophercloud.ServiceClient, networkID string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, networkID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, networkID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 	return res
 }

--- a/rackspace/compute/v2/virtualinterfaces/requests.go
+++ b/rackspace/compute/v2/virtualinterfaces/requests.go
@@ -3,8 +3,6 @@ package virtualinterfaces
 import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
-
-	"github.com/racker/perigee"
 )
 
 // List returns a Pager which allows you to iterate over a collection of
@@ -30,11 +28,10 @@ func Create(c *gophercloud.ServiceClient, instanceID, networkID string) CreateRe
 	}
 
 	// Send request to API
-	_, res.Err = perigee.Request("POST", createURL(c, instanceID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200, 201, 202},
+	_, res.Err = c.Request("POST", createURL(c, instanceID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200, 201, 202},
 	})
 	return res
 }
@@ -43,9 +40,8 @@ func Create(c *gophercloud.ServiceClient, instanceID, networkID string) CreateRe
 // instanceID.
 func Delete(c *gophercloud.ServiceClient, instanceID, interfaceID string) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", deleteURL(c, instanceID, interfaceID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 204},
+	_, res.Err = c.Request("DELETE", deleteURL(c, instanceID, interfaceID), gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
 	})
 	return res
 }

--- a/rackspace/identity/v2/roles/delegate.go
+++ b/rackspace/identity/v2/roles/delegate.go
@@ -1,7 +1,6 @@
 package roles
 
 import (
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 
@@ -20,9 +19,8 @@ func List(client *gophercloud.ServiceClient) pagination.Pager {
 func AddUserRole(client *gophercloud.ServiceClient, userID, roleID string) UserRoleResult {
 	var result UserRoleResult
 
-	_, result.Err = perigee.Request("PUT", userRoleURL(client, userID, roleID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 201},
+	_, result.Err = client.Request("PUT", userRoleURL(client, userID, roleID), gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
 	})
 
 	return result
@@ -34,9 +32,8 @@ func AddUserRole(client *gophercloud.ServiceClient, userID, roleID string) UserR
 func DeleteUserRole(client *gophercloud.ServiceClient, userID, roleID string) UserRoleResult {
 	var result UserRoleResult
 
-	_, result.Err = perigee.Request("DELETE", userRoleURL(client, userID, roleID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{204},
+	_, result.Err = client.Request("DELETE", userRoleURL(client, userID, roleID), gophercloud.RequestOpts{
+		OkCodes: []int{204},
 	})
 
 	return result

--- a/rackspace/identity/v2/users/delegate.go
+++ b/rackspace/identity/v2/users/delegate.go
@@ -3,7 +3,6 @@ package users
 import (
 	"errors"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	os "github.com/rackspace/gophercloud/openstack/identity/v2/users"
 	"github.com/rackspace/gophercloud/pagination"
@@ -116,11 +115,10 @@ func (opts UpdateOpts) ToUserUpdateMap() map[string]interface{} {
 func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) UpdateResult {
 	var result UpdateResult
 
-	_, result.Err = perigee.Request("POST", os.ResourceURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		ReqBody:     opts.ToUserUpdateMap(),
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", os.ResourceURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		JSONBody:     opts.ToUserUpdateMap(),
+		OkCodes:      []int{200},
 	})
 
 	return result
@@ -135,10 +133,9 @@ func Delete(client *gophercloud.ServiceClient, id string) os.DeleteResult {
 func ResetAPIKey(client *gophercloud.ServiceClient, id string) ResetAPIKeyResult {
 	var result ResetAPIKeyResult
 
-	_, result.Err = perigee.Request("POST", resetAPIKeyURL(client, id), perigee.Options{
-		Results:     &result.Body,
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, result.Err = client.Request("POST", resetAPIKeyURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &result.Body,
+		OkCodes:      []int{200},
 	})
 
 	return result

--- a/rackspace/lb/v1/acl/requests.go
+++ b/rackspace/lb/v1/acl/requests.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -75,10 +74,9 @@ func Create(client *gophercloud.ServiceClient, loadBalancerID int, opts CreateOp
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", rootURL(client, loadBalancerID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("POST", rootURL(client, loadBalancerID), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -107,9 +105,8 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, itemIDs []int)
 // Delete will remove a single network item from a load balancer's access list.
 func Delete(c *gophercloud.ServiceClient, lbID, itemID int) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, lbID, itemID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", resourceURL(c, lbID, itemID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }
@@ -118,9 +115,8 @@ func Delete(c *gophercloud.ServiceClient, lbID, itemID int) DeleteResult {
 // effectively resetting it and allowing all traffic.
 func DeleteAll(c *gophercloud.ServiceClient, lbID int) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", rootURL(c, lbID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/rackspace/lb/v1/acl/requests.go
+++ b/rackspace/lb/v1/acl/requests.go
@@ -97,9 +97,8 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, itemIDs []int)
 	url := rootURL(c, loadBalancerID)
 	url += gophercloud.IDSliceToQueryString("id", itemIDs)
 
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/lbs/requests.go
+++ b/rackspace/lb/v1/lbs/requests.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/racker/perigee"
 
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
@@ -244,10 +243,9 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 func Get(c *gophercloud.ServiceClient, id int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -282,9 +280,8 @@ func BulkDelete(c *gophercloud.ServiceClient, ids []int) DeleteResult {
 func Delete(c *gophercloud.ServiceClient, id int) DeleteResult {
 	var res DeleteResult
 
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", resourceURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res
@@ -366,10 +363,9 @@ func Update(c *gophercloud.ServiceClient, id int, opts UpdateOptsBuilder) Update
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", resourceURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", resourceURL(c, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -398,10 +394,9 @@ func ListAlgorithms(client *gophercloud.ServiceClient) pagination.Pager {
 func IsLoggingEnabled(client *gophercloud.ServiceClient, id int) (bool, error) {
 	var body interface{}
 
-	_, err := perigee.Request("GET", loggingURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &body,
-		OkCodes:     []int{200},
+	_, err := client.Request("GET", loggingURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &body,
+		OkCodes:      []int{200},
 	})
 	if err != nil {
 		return false, err
@@ -428,10 +423,9 @@ func EnableLogging(client *gophercloud.ServiceClient, id int) gophercloud.ErrRes
 	reqBody := toConnLoggingMap(true)
 	var res gophercloud.ErrResult
 
-	_, res.Err = perigee.Request("PUT", loggingURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("PUT", loggingURL(client, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -442,10 +436,9 @@ func DisableLogging(client *gophercloud.ServiceClient, id int) gophercloud.ErrRe
 	reqBody := toConnLoggingMap(false)
 	var res gophercloud.ErrResult
 
-	_, res.Err = perigee.Request("PUT", loggingURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("PUT", loggingURL(client, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -455,10 +448,9 @@ func DisableLogging(client *gophercloud.ServiceClient, id int) gophercloud.ErrRe
 func GetErrorPage(client *gophercloud.ServiceClient, id int) ErrorPageResult {
 	var res ErrorPageResult
 
-	_, res.Err = perigee.Request("GET", errorPageURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("GET", errorPageURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -472,11 +464,10 @@ func SetErrorPage(client *gophercloud.ServiceClient, id int, html string) ErrorP
 	type stringMap map[string]string
 	reqBody := map[string]stringMap{"errorpage": stringMap{"content": html}}
 
-	_, res.Err = perigee.Request("PUT", errorPageURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		ReqBody:     &reqBody,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("PUT", errorPageURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		JSONBody:     &reqBody,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -486,9 +477,8 @@ func SetErrorPage(client *gophercloud.ServiceClient, id int, html string) ErrorP
 func DeleteErrorPage(client *gophercloud.ServiceClient, id int) gophercloud.ErrResult {
 	var res gophercloud.ErrResult
 
-	_, res.Err = perigee.Request("DELETE", errorPageURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("DELETE", errorPageURL(client, id), gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 
 	return res
@@ -498,10 +488,9 @@ func DeleteErrorPage(client *gophercloud.ServiceClient, id int) gophercloud.ErrR
 func GetStats(client *gophercloud.ServiceClient, id int) StatsResult {
 	var res StatsResult
 
-	_, res.Err = perigee.Request("GET", statsURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = client.Request("GET", statsURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -518,10 +507,9 @@ func GetStats(client *gophercloud.ServiceClient, id int) StatsResult {
 func IsContentCached(client *gophercloud.ServiceClient, id int) (bool, error) {
 	var body interface{}
 
-	_, err := perigee.Request("GET", cacheURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		Results:     &body,
-		OkCodes:     []int{200},
+	_, err := client.Request("GET", cacheURL(client, id), gophercloud.RequestOpts{
+		JSONResponse: &body,
+		OkCodes:      []int{200},
 	})
 	if err != nil {
 		return false, err
@@ -548,10 +536,9 @@ func EnableCaching(client *gophercloud.ServiceClient, id int) gophercloud.ErrRes
 	reqBody := toCachingMap(true)
 	var res gophercloud.ErrResult
 
-	_, res.Err = perigee.Request("PUT", cacheURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("PUT", cacheURL(client, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -562,10 +549,9 @@ func DisableCaching(client *gophercloud.ServiceClient, id int) gophercloud.ErrRe
 	reqBody := toCachingMap(false)
 	var res gophercloud.ErrResult
 
-	_, res.Err = perigee.Request("PUT", cacheURL(client, id), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = client.Request("PUT", cacheURL(client, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/lbs/requests.go
+++ b/rackspace/lb/v1/lbs/requests.go
@@ -228,11 +228,10 @@ func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", rootURL(c), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("POST", rootURL(c), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 
 	return res
@@ -272,9 +271,8 @@ func BulkDelete(c *gophercloud.ServiceClient, ids []int) DeleteResult {
 	url := rootURL(c)
 	url += gophercloud.IDSliceToQueryString("id", ids)
 
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/monitors/requests.go
+++ b/rackspace/lb/v1/monitors/requests.go
@@ -3,8 +3,6 @@ package monitors
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 )
 
@@ -143,10 +141,9 @@ func Update(c *gophercloud.ServiceClient, id int, opts UpdateOptsBuilder) Update
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", rootURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", rootURL(c, id), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -156,10 +153,9 @@ func Update(c *gophercloud.ServiceClient, id int, opts UpdateOptsBuilder) Update
 func Get(c *gophercloud.ServiceClient, id int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", rootURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", rootURL(c, id), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -169,9 +165,8 @@ func Get(c *gophercloud.ServiceClient, id int) GetResult {
 func Delete(c *gophercloud.ServiceClient, id int) DeleteResult {
 	var res DeleteResult
 
-	_, res.Err = perigee.Request("DELETE", rootURL(c, id), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", rootURL(c, id), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/nodes/requests.go
+++ b/rackspace/lb/v1/nodes/requests.go
@@ -147,9 +147,8 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, nodeIDs []int)
 	url := rootURL(c, loadBalancerID)
 	url += gophercloud.IDSliceToQueryString("id", nodeIDs)
 
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/nodes/requests.go
+++ b/rackspace/lb/v1/nodes/requests.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -113,18 +112,17 @@ func Create(client *gophercloud.ServiceClient, loadBalancerID int, opts CreateOp
 		return res
 	}
 
-	resp, err := perigee.Request("POST", rootURL(client, loadBalancerID), perigee.Options{
-		MoreHeaders: client.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	resp, err := client.Request("POST", rootURL(client, loadBalancerID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 	if err != nil {
 		res.Err = err
 		return res
 	}
 
-	pr, err := pagination.PageResultFrom(&resp.HttpResponse)
+	pr, err := pagination.PageResultFrom(resp)
 	if err != nil {
 		res.Err = err
 		return res
@@ -158,10 +156,9 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, nodeIDs []int)
 func Get(c *gophercloud.ServiceClient, lbID, nodeID int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", resourceURL(c, lbID, nodeID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", resourceURL(c, lbID, nodeID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -216,10 +213,9 @@ func Update(c *gophercloud.ServiceClient, lbID, nodeID int, opts UpdateOptsBuild
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", resourceURL(c, lbID, nodeID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", resourceURL(c, lbID, nodeID), gophercloud.RequestOpts{
+		JSONBody: &reqBody,
+		OkCodes:  []int{202},
 	})
 
 	return res
@@ -228,9 +224,8 @@ func Update(c *gophercloud.ServiceClient, lbID, nodeID int, opts UpdateOptsBuild
 // Delete is the operation responsible for permanently deleting a node.
 func Delete(c *gophercloud.ServiceClient, lbID, nodeID int) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, lbID, nodeID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", resourceURL(c, lbID, nodeID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/rackspace/lb/v1/sessions/requests.go
+++ b/rackspace/lb/v1/sessions/requests.go
@@ -3,8 +3,6 @@ package sessions
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 )
 
@@ -44,11 +42,10 @@ func Enable(c *gophercloud.ServiceClient, lbID int, opts CreateOptsBuilder) Enab
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 
 	return res
@@ -59,10 +56,9 @@ func Enable(c *gophercloud.ServiceClient, lbID int, opts CreateOptsBuilder) Enab
 func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -73,9 +69,8 @@ func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 func Disable(c *gophercloud.ServiceClient, lbID int) DisableResult {
 	var res DisableResult
 
-	_, res.Err = perigee.Request("DELETE", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", rootURL(c, lbID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/ssl/requests.go
+++ b/rackspace/lb/v1/ssl/requests.go
@@ -3,8 +3,6 @@ package ssl
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -87,11 +85,10 @@ func Update(c *gophercloud.ServiceClient, lbID int, opts UpdateOptsBuilder) Upda
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("PUT", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -102,10 +99,9 @@ func Update(c *gophercloud.ServiceClient, lbID int, opts UpdateOptsBuilder) Upda
 func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -116,9 +112,8 @@ func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 func Delete(c *gophercloud.ServiceClient, lbID int) DeleteResult {
 	var res DeleteResult
 
-	_, res.Err = perigee.Request("DELETE", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("DELETE", rootURL(c, lbID), gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 
 	return res
@@ -185,11 +180,10 @@ func CreateCert(c *gophercloud.ServiceClient, lbID int, opts CreateCertOptsBuild
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", certURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("POST", certURL(c, lbID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -199,10 +193,9 @@ func CreateCert(c *gophercloud.ServiceClient, lbID int, opts CreateCertOptsBuild
 func GetCert(c *gophercloud.ServiceClient, lbID, certID int) GetCertResult {
 	var res GetCertResult
 
-	_, res.Err = perigee.Request("GET", certResourceURL(c, lbID, certID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", certResourceURL(c, lbID, certID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -254,11 +247,10 @@ func UpdateCert(c *gophercloud.ServiceClient, lbID, certID int, opts UpdateCertO
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", certResourceURL(c, lbID, certID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", certResourceURL(c, lbID, certID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 
 	return res
@@ -269,9 +261,8 @@ func UpdateCert(c *gophercloud.ServiceClient, lbID, certID int, opts UpdateCertO
 func DeleteCert(c *gophercloud.ServiceClient, lbID, certID int) DeleteResult {
 	var res DeleteResult
 
-	_, res.Err = perigee.Request("DELETE", certResourceURL(c, lbID, certID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("DELETE", certResourceURL(c, lbID, certID), gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 
 	return res

--- a/rackspace/lb/v1/throttle/requests.go
+++ b/rackspace/lb/v1/throttle/requests.go
@@ -3,8 +3,6 @@ package throttle
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 )
 
@@ -57,11 +55,10 @@ func Create(c *gophercloud.ServiceClient, lbID int, opts CreateOptsBuilder) Crea
 		return res
 	}
 
-	_, res.Err = perigee.Request("PUT", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("PUT", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 
 	return res
@@ -72,10 +69,9 @@ func Create(c *gophercloud.ServiceClient, lbID int, opts CreateOptsBuilder) Crea
 func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 	var res GetResult
 
-	_, res.Err = perigee.Request("GET", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		Results:     &res.Body,
-		OkCodes:     []int{200},
+	_, res.Err = c.Request("GET", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONResponse: &res.Body,
+		OkCodes:      []int{200},
 	})
 
 	return res
@@ -86,9 +82,8 @@ func Get(c *gophercloud.ServiceClient, lbID int) GetResult {
 func Delete(c *gophercloud.ServiceClient, lbID int) DeleteResult {
 	var res DeleteResult
 
-	_, res.Err = perigee.Request("DELETE", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", rootURL(c, lbID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/vips/requests.go
+++ b/rackspace/lb/v1/vips/requests.go
@@ -93,9 +93,8 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, vipIDs []int) 
 	url := rootURL(c, loadBalancerID)
 	url += gophercloud.IDSliceToQueryString("id", vipIDs)
 
-	_, res.Err = perigee.Request("DELETE", url, perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", url, gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 
 	return res

--- a/rackspace/lb/v1/vips/requests.go
+++ b/rackspace/lb/v1/vips/requests.go
@@ -3,8 +3,6 @@ package vips
 import (
 	"errors"
 
-	"github.com/racker/perigee"
-
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -69,11 +67,10 @@ func Create(c *gophercloud.ServiceClient, lbID int, opts CreateOptsBuilder) Crea
 		return res
 	}
 
-	_, res.Err = perigee.Request("POST", rootURL(c, lbID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		ReqBody:     &reqBody,
-		Results:     &res.Body,
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("POST", rootURL(c, lbID), gophercloud.RequestOpts{
+		JSONBody:     &reqBody,
+		JSONResponse: &res.Body,
+		OkCodes:      []int{202},
 	})
 
 	return res
@@ -103,9 +100,8 @@ func BulkDelete(c *gophercloud.ServiceClient, loadBalancerID int, vipIDs []int) 
 // Delete is the operation responsible for permanently deleting a VIP.
 func Delete(c *gophercloud.ServiceClient, lbID, vipID int) DeleteResult {
 	var res DeleteResult
-	_, res.Err = perigee.Request("DELETE", resourceURL(c, lbID, vipID), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{202},
+	_, res.Err = c.Request("DELETE", resourceURL(c, lbID, vipID), gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	return res
 }

--- a/rackspace/objectstorage/v1/bulk/requests.go
+++ b/rackspace/objectstorage/v1/bulk/requests.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 )
 
@@ -38,14 +37,13 @@ func Delete(c *gophercloud.ServiceClient, opts DeleteOptsBuilder) DeleteResult {
 
 	reqBody := strings.NewReader(reqString)
 
-	resp, err := perigee.Request("DELETE", deleteURL(c), perigee.Options{
-		ContentType: "text/plain",
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200},
-		ReqBody:     reqBody,
-		Results:     &res.Body,
+	resp, err := c.Request("DELETE", deleteURL(c), gophercloud.RequestOpts{
+		MoreHeaders:  map[string]string{"Content-Type": "text/plain"},
+		OkCodes:      []int{200},
+		JSONBody:     reqBody,
+		JSONResponse: &res.Body,
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }

--- a/rackspace/objectstorage/v1/cdncontainers/requests.go
+++ b/rackspace/objectstorage/v1/cdncontainers/requests.go
@@ -3,7 +3,6 @@ package cdncontainers
 import (
 	"strconv"
 
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 )
 
@@ -50,11 +49,11 @@ func Enable(c *gophercloud.ServiceClient, containerName string, opts EnableOptsB
 		}
 	}
 
-	resp, err := perigee.Request("PUT", enableURL(c, containerName), perigee.Options{
+	resp, err := c.Request("PUT", enableURL(c, containerName), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -64,11 +63,10 @@ func Enable(c *gophercloud.ServiceClient, containerName string, opts EnableOptsB
 // function.
 func Get(c *gophercloud.ServiceClient, containerName string) GetResult {
 	var res GetResult
-	resp, err := perigee.Request("HEAD", getURL(c, containerName), perigee.Options{
-		MoreHeaders: c.AuthenticatedHeaders(),
-		OkCodes:     []int{200, 204},
+	resp, err := c.Request("HEAD", getURL(c, containerName), gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }
@@ -147,11 +145,11 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 		}
 	}
 
-	resp, err := perigee.Request("POST", updateURL(c, containerName), perigee.Options{
+	resp, err := c.Request("POST", updateURL(c, containerName), gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{202, 204},
 	})
-	res.Header = resp.HttpResponse.Header
+	res.Header = resp.Header
 	res.Err = err
 	return res
 }


### PR DESCRIPTION
This is a follow-on PR to #365 that uses the new, centralized request method throughout the existing codebase. It uses a [terrible, hacked-up Ruby script](https://gist.github.com/smashwilson/aa1c19c0c4d679883f8a) to automate the conversion process (for all the easy cases).