### PR TITLE
List Server Addresses; Closes #286

### DIFF
--- a/acceptance/openstack/compute/v2/compute_test.go
+++ b/acceptance/openstack/compute/v2/compute_test.go
@@ -56,6 +56,9 @@ type ComputeChoices struct {
 	// FlavorIDResize contains the ID of a different flavor available on the same OpenStack installation, that is distinct
 	// from FlavorID.
 	FlavorIDResize string
+
+	// NetworkName is the name of a network to launch the instance on.
+	NetworkName string
 }
 
 // ComputeChoicesFromEnv populates a ComputeChoices struct from environment variables.
@@ -64,6 +67,7 @@ func ComputeChoicesFromEnv() (*ComputeChoices, error) {
 	imageID := os.Getenv("OS_IMAGE_ID")
 	flavorID := os.Getenv("OS_FLAVOR_ID")
 	flavorIDResize := os.Getenv("OS_FLAVOR_ID_RESIZE")
+	networkName := os.Getenv("OS_NETWORK_NAME")
 
 	missing := make([]string, 0, 3)
 	if imageID == "" {
@@ -74,6 +78,9 @@ func ComputeChoicesFromEnv() (*ComputeChoices, error) {
 	}
 	if flavorIDResize == "" {
 		missing = append(missing, "OS_FLAVOR_ID_RESIZE")
+	}
+	if networkName == "" {
+		networkName = "public"
 	}
 
 	notDistinct := ""
@@ -93,5 +100,5 @@ func ComputeChoicesFromEnv() (*ComputeChoices, error) {
 		return nil, fmt.Errorf(text)
 	}
 
-	return &ComputeChoices{ImageID: imageID, FlavorID: flavorID, FlavorIDResize: flavorIDResize}, nil
+	return &ComputeChoices{ImageID: imageID, FlavorID: flavorID, FlavorIDResize: flavorIDResize, NetworkName: networkName}, nil
 }

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -57,7 +57,6 @@ func networkingClient() (*gophercloud.ServiceClient, error) {
 	}
 
 	return openstack.NewNetworkV2(provider, gophercloud.EndpointOpts{
-		Name:   "neutron",
 		Region: os.Getenv("OS_REGION_NAME"),
 	})
 }
@@ -74,7 +73,10 @@ func createServer(t *testing.T, client *gophercloud.ServiceClient, choices *Comp
 		t.Fatalf("Unable to create a networking client: %v", err)
 	}
 
-	pager := networks.List(networkingClient, networks.ListOpts{Name: "public", Limit: 1})
+	pager := networks.List(networkingClient, networks.ListOpts{
+		Name:  choices.NetworkName,
+		Limit: 1,
+	})
 	pager.EachPage(func(page pagination.Page) (bool, error) {
 		networks, err := networks.ExtractNetworks(page)
 		if err != nil {
@@ -152,7 +154,7 @@ func TestCreateDestroyServer(t *testing.T) {
 		return true, nil
 	})
 
-	pager = servers.ListAddressesByNetwork(client, server.ID, "public")
+	pager = servers.ListAddressesByNetwork(client, server.ID, choices.NetworkName)
 	pager.EachPage(func(page pagination.Page) (bool, error) {
 		addresses, err := servers.ExtractNetworkAddresses(page)
 		if err != nil {

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -154,13 +154,13 @@ func TestCreateDestroyServer(t *testing.T) {
 
 	pager = servers.ListAddressesByNetwork(client, server.ID, "public")
 	pager.EachPage(func(page pagination.Page) (bool, error) {
-		network, err := servers.ExtractNetworkAddresses(page)
+		addresses, err := servers.ExtractNetworkAddresses(page)
 		if err != nil {
 			return false, err
 		}
 
-		for n, a := range network {
-			t.Logf("%s: %+v\n", n, a)
+		for _, a := range addresses {
+			t.Logf("%+v\n", a)
 		}
 		return true, nil
 	})

--- a/acceptance/openstack/compute/v2/servers_test.go
+++ b/acceptance/openstack/compute/v2/servers_test.go
@@ -138,6 +138,32 @@ func TestCreateDestroyServer(t *testing.T) {
 	if err = waitForStatus(client, server, "ACTIVE"); err != nil {
 		t.Fatalf("Unable to wait for server: %v", err)
 	}
+
+	pager := servers.ListAddresses(client, server.ID)
+	pager.EachPage(func(page pagination.Page) (bool, error) {
+		networks, err := servers.ExtractAddresses(page)
+		if err != nil {
+			return false, err
+		}
+
+		for n, a := range networks {
+			t.Logf("%s: %+v\n", n, a)
+		}
+		return true, nil
+	})
+
+	pager = servers.ListAddressesByNetwork(client, server.ID, "public")
+	pager.EachPage(func(page pagination.Page) (bool, error) {
+		network, err := servers.ExtractNetworkAddresses(page)
+		if err != nil {
+			return false, err
+		}
+
+		for n, a := range network {
+			t.Logf("%s: %+v\n", n, a)
+		}
+		return true, nil
+	})
 }
 
 func TestUpdateServer(t *testing.T) {

--- a/openstack/compute/v2/servers/fixtures.go
+++ b/openstack/compute/v2/servers/fixtures.go
@@ -567,3 +567,53 @@ func HandleMetadataUpdateSuccessfully(t *testing.T) {
 		w.Write([]byte(`{ "metadata": {"foo":"baz", "this":"those"}}`))
 	})
 }
+
+// ListAddressesExpected represents an expected repsonse from a ListAddresses request.
+var ListAddressesExpected = map[string][]Address{
+	"public": []Address{
+		Address{
+			Version: 4,
+			Address: "80.56.136.39",
+		},
+		Address{
+			Version: 6,
+			Address: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		},
+	},
+	"private": []Address{
+		Address{
+			Version: 4,
+			Address: "10.880.3.154",
+		},
+	},
+}
+
+// HandleAddressListSuccessfully sets up the test server to respond to a ListAddresses request.
+func HandleAddressListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/asdfasdfasdf/ips", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"addresses": {
+				"public": [
+				{
+					"version": 4,
+					"addr": "50.56.176.35"
+				},
+				{
+					"version": 6,
+					"addr": "2001:4800:780e:510:be76:4eff:fe04:84a8"
+				}
+				],
+				"private": [
+				{
+					"version": 4,
+					"addr": "10.180.3.155"
+				}
+				]
+			}
+		}`)
+	})
+}

--- a/openstack/compute/v2/servers/fixtures.go
+++ b/openstack/compute/v2/servers/fixtures.go
@@ -619,16 +619,14 @@ func HandleAddressListSuccessfully(t *testing.T) {
 }
 
 // ListNetworkAddressesExpected represents an expected repsonse from a ListAddressesByNetwork request.
-var ListNetworkAddressesExpected = map[string][]Address{
-	"public": []Address{
-		Address{
-			Version: 4,
-			Address: "80.56.136.39",
-		},
-		Address{
-			Version: 6,
-			Address: "2001:4800:790e:510:be76:4eff:fe04:82a8",
-		},
+var ListNetworkAddressesExpected = []Address{
+	Address{
+		Version: 4,
+		Address: "50.56.176.35",
+	},
+	Address{
+		Version: 6,
+		Address: "2001:4800:780e:510:be76:4eff:fe04:84a8",
 	},
 }
 

--- a/openstack/compute/v2/servers/fixtures.go
+++ b/openstack/compute/v2/servers/fixtures.go
@@ -617,3 +617,39 @@ func HandleAddressListSuccessfully(t *testing.T) {
 		}`)
 	})
 }
+
+// ListNetworkAddressesExpected represents an expected repsonse from a ListAddressesByNetwork request.
+var ListNetworkAddressesExpected = map[string][]Address{
+	"public": []Address{
+		Address{
+			Version: 4,
+			Address: "80.56.136.39",
+		},
+		Address{
+			Version: 6,
+			Address: "2001:4800:790e:510:be76:4eff:fe04:82a8",
+		},
+	},
+}
+
+// HandleNetworkAddressListSuccessfully sets up the test server to respond to a ListAddressesByNetwork request.
+func HandleNetworkAddressListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/asdfasdfasdf/ips/public", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"public": [
+			{
+				"version": 4,
+				"addr": "50.56.176.35"
+				},
+				{
+					"version": 6,
+					"addr": "2001:4800:780e:510:be76:4eff:fe04:84a8"
+				}
+			]
+			}`)
+	})
+}

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -719,3 +719,11 @@ func DeleteMetadatum(client *gophercloud.ServiceClient, id, key string) DeleteMe
 	})
 	return res
 }
+
+// ListAddresses makes a request against the API to list the servers IP addresses.
+func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	createPageFn := func(r pagination.PageResult) pagination.Page {
+		return AddressPage{pagination.SinglePageBase(r)}
+	}
+	return pagination.NewPager(client, listAddressesURL(client, id), createPageFn)
+}

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -727,3 +727,12 @@ func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Page
 	}
 	return pagination.NewPager(client, listAddressesURL(client, id), createPageFn)
 }
+
+// ListAddressesByNetwork makes a request against the API to list the servers IP addresses
+// for the given network.
+func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network string) pagination.Pager {
+	createPageFn := func(r pagination.PageResult) pagination.Page {
+		return NetworkAddressPage{pagination.SinglePageBase(r)}
+	}
+	return pagination.NewPager(client, listAddressesByNetworkURL(client, id, network), createPageFn)
+}

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -302,8 +302,8 @@ func TestListAddressesByNetwork(t *testing.T) {
 		actual, err := ExtractNetworkAddresses(page)
 		th.AssertNoErr(t, err)
 
-		if len(actual) != 1 {
-			t.Fatalf("Expected 1 network, got %d", len(actual))
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 addresses, got %d", len(actual))
 		}
 		th.CheckDeepEquals(t, expected, actual)
 

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -279,7 +279,31 @@ func TestListAddresses(t *testing.T) {
 		th.AssertNoErr(t, err)
 
 		if len(actual) != 2 {
-			t.Fatalf("Expected 2 servers, got %d", len(actual))
+			t.Fatalf("Expected 2 networks, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}
+
+func TestListAddressesByNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressListSuccessfully(t)
+
+	expected := ListNetworkAddressesExpected
+	pages := 0
+	err := ListAddressesByNetwork(client.ServiceClient(), "asdfasdfasdf", "public").EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ExtractNetworkAddresses(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 network, got %d", len(actual))
 		}
 		th.CheckDeepEquals(t, expected, actual)
 

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -264,3 +264,27 @@ func TestUpdateMetadata(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertDeepEquals(t, expected, actual)
 }
+
+func TestListAddresses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAddressListSuccessfully(t)
+
+	expected := ListAddressesExpected
+	pages := 0
+	err := ListAddresses(client.ServiceClient(), "asdfasdfasdf").EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ExtractAddresses(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 servers, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -328,8 +328,8 @@ func (r NetworkAddressPage) IsEmpty() (bool, error) {
 }
 
 // ExtractNetworkAddresses interprets the results of a single page from a ListAddressesByNetwork() call,
-// producing a map of addresses.
-func ExtractNetworkAddresses(page pagination.Page) (map[string][]Address, error) {
+// producing a slice of addresses.
+func ExtractNetworkAddresses(page pagination.Page) ([]Address, error) {
 	casted := page.(NetworkAddressPage).Body
 
 	var response map[string][]Address
@@ -338,5 +338,10 @@ func ExtractNetworkAddresses(page pagination.Page) (map[string][]Address, error)
 		return nil, err
 	}
 
-	return response, err
+	var key string
+	for k := range response {
+		key = k
+	}
+
+	return response[key], err
 }

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -278,14 +278,14 @@ type Address struct {
 	Address string `mapstructure:"addr"`
 }
 
-// AddressPage abstracts the raw results of making a List() request against the API.
+// AddressPage abstracts the raw results of making a ListAddresses() request against the API.
 // As OpenStack extensions may freely alter the response bodies of structures returned
 // to the client, you may only safely access the data provided through the ExtractAddresses call.
 type AddressPage struct {
 	pagination.SinglePageBase
 }
 
-// IsEmpty returns true if an AddressPage contains no addresses.
+// IsEmpty returns true if an AddressPage contains no networks.
 func (r AddressPage) IsEmpty() (bool, error) {
 	addresses, err := ExtractAddresses(r)
 	if err != nil {
@@ -294,7 +294,7 @@ func (r AddressPage) IsEmpty() (bool, error) {
 	return len(addresses) == 0, nil
 }
 
-// ExtractAddresses interprets the results of a single page from a List() call,
+// ExtractAddresses interprets the results of a single page from a ListAddresses() call,
 // producing a map of addresses.
 func ExtractAddresses(page pagination.Page) (map[string][]Address, error) {
 	casted := page.(AddressPage).Body
@@ -309,4 +309,34 @@ func ExtractAddresses(page pagination.Page) (map[string][]Address, error) {
 	}
 
 	return response.Addresses, err
+}
+
+// NetworkAddressPage abstracts the raw results of making a ListAddressesByNetwork() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned
+// to the client, you may only safely access the data provided through the ExtractAddresses call.
+type NetworkAddressPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a NetworkAddressPage contains no addresses.
+func (r NetworkAddressPage) IsEmpty() (bool, error) {
+	addresses, err := ExtractNetworkAddresses(r)
+	if err != nil {
+		return true, err
+	}
+	return len(addresses) == 0, nil
+}
+
+// ExtractNetworkAddresses interprets the results of a single page from a ListAddressesByNetwork() call,
+// producing a map of addresses.
+func ExtractNetworkAddresses(page pagination.Page) (map[string][]Address, error) {
+	casted := page.(NetworkAddressPage).Body
+
+	var response map[string][]Address
+	err := mapstructure.Decode(casted, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, err
 }

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -194,7 +194,6 @@ func ExtractServers(page pagination.Page) ([]Server, error) {
 
 	err = decoder.Decode(casted)
 
-	//err := mapstructure.Decode(casted, &response)
 	return response.Servers, err
 }
 
@@ -271,4 +270,43 @@ func toMapFromString(from reflect.Kind, to reflect.Kind, data interface{}) (inte
 		return map[string]interface{}{}, nil
 	}
 	return data, nil
+}
+
+// Address represents an IP address.
+type Address struct {
+	Version int    `mapstructure:"version"`
+	Address string `mapstructure:"addr"`
+}
+
+// AddressPage abstracts the raw results of making a List() request against the API.
+// As OpenStack extensions may freely alter the response bodies of structures returned
+// to the client, you may only safely access the data provided through the ExtractAddresses call.
+type AddressPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if an AddressPage contains no addresses.
+func (r AddressPage) IsEmpty() (bool, error) {
+	addresses, err := ExtractAddresses(r)
+	if err != nil {
+		return true, err
+	}
+	return len(addresses) == 0, nil
+}
+
+// ExtractAddresses interprets the results of a single page from a List() call,
+// producing a map of addresses.
+func ExtractAddresses(page pagination.Page) (map[string][]Address, error) {
+	casted := page.(AddressPage).Body
+
+	var response struct {
+		Addresses map[string][]Address `mapstructure:"addresses"`
+	}
+
+	err := mapstructure.Decode(casted, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Addresses, err
 }

--- a/openstack/compute/v2/servers/urls.go
+++ b/openstack/compute/v2/servers/urls.go
@@ -37,3 +37,7 @@ func metadatumURL(client *gophercloud.ServiceClient, id, key string) string {
 func metadataURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "metadata")
 }
+
+func listAddressesURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "ips")
+}

--- a/openstack/compute/v2/servers/urls.go
+++ b/openstack/compute/v2/servers/urls.go
@@ -41,3 +41,7 @@ func metadataURL(client *gophercloud.ServiceClient, id string) string {
 func listAddressesURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "ips")
 }
+
+func listAddressesByNetworkURL(client *gophercloud.ServiceClient, id, network string) string {
+	return client.ServiceURL("servers", id, "ips", network)
+}

--- a/rackspace/compute/v2/servers/delegate.go
+++ b/rackspace/compute/v2/servers/delegate.go
@@ -64,3 +64,24 @@ func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) er
 func ExtractServers(page pagination.Page) ([]os.Server, error) {
 	return os.ExtractServers(page)
 }
+
+// ListAddresses makes a request against the API to list the servers IP addresses.
+func ListAddresses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	return os.ListAddresses(client, id)
+}
+
+// ExtractAddresses interprets the results of a single page from a ListAddresses() call, producing a map of Address slices.
+func ExtractAddresses(page pagination.Page) (map[string][]os.Address, error) {
+	return os.ExtractAddresses(page)
+}
+
+// ListAddressesByNetwork makes a request against the API to list the servers IP addresses
+// for the given network.
+func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network string) pagination.Pager {
+	return os.ListAddressesByNetwork(client, id, network)
+}
+
+// ExtractNetworkAddresses interprets the results of a single page from a ListAddressesByNetwork() call, producing a map of Address slices.
+func ExtractNetworkAddresses(page pagination.Page) (map[string][]os.Address, error) {
+	return os.ExtractNetworkAddresses(page)
+}

--- a/rackspace/compute/v2/servers/delegate.go
+++ b/rackspace/compute/v2/servers/delegate.go
@@ -82,6 +82,6 @@ func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network strin
 }
 
 // ExtractNetworkAddresses interprets the results of a single page from a ListAddressesByNetwork() call, producing a map of Address slices.
-func ExtractNetworkAddresses(page pagination.Page) (map[string][]os.Address, error) {
+func ExtractNetworkAddresses(page pagination.Page) ([]os.Address, error) {
 	return os.ExtractNetworkAddresses(page)
 }

--- a/rackspace/compute/v2/servers/delegate_test.go
+++ b/rackspace/compute/v2/servers/delegate_test.go
@@ -170,8 +170,8 @@ func TestListAddressesByNetwork(t *testing.T) {
 		actual, err := ExtractNetworkAddresses(page)
 		th.AssertNoErr(t, err)
 
-		if len(actual) != 1 {
-			t.Fatalf("Expected 1 network, got %d", len(actual))
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 addresses, got %d", len(actual))
 		}
 		th.CheckDeepEquals(t, expected, actual)
 

--- a/rackspace/compute/v2/servers/delegate_test.go
+++ b/rackspace/compute/v2/servers/delegate_test.go
@@ -132,3 +132,51 @@ func TestRebuildServer(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, &GophercloudServer, actual)
 }
+
+func TestListAddresses(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	os.HandleAddressListSuccessfully(t)
+
+	expected := os.ListAddressesExpected
+	pages := 0
+	err := ListAddresses(client.ServiceClient(), "asdfasdfasdf").EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ExtractAddresses(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 networks, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}
+
+func TestListAddressesByNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	os.HandleNetworkAddressListSuccessfully(t)
+
+	expected := os.ListNetworkAddressesExpected
+	pages := 0
+	err := ListAddressesByNetwork(client.ServiceClient(), "asdfasdfasdf", "public").EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+
+		actual, err := ExtractNetworkAddresses(page)
+		th.AssertNoErr(t, err)
+
+		if len(actual) != 1 {
+			t.Fatalf("Expected 1 network, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, pages)
+}


### PR DESCRIPTION
This PR implements functionality to list server addresses. When complete, it will close #286 .

- [x] List Server Addresses Operation (OpenStack)
- [x] List Server Addresses Unit Test (OpenStack)
- [x] List Server Addresses Acceptance Test (OpenStack)
- [x] List Server Addresses by Network Operation (OpenStack)
- [x] List Server Addresses by Network Unit Test (OpenStack)
- [x] List Server Addresses by Network Acceptance Test (OpenStack)
- [x] List Server Addresses Operation (Rackspace)
- [x] List Server Addresses Unit Test (Rackspace)
- [x] List Server Addresses Acceptance Test (Rackspace)
- [x] List Server Addresses by Network Operation (Rackspace)
- [x] List Server Addresses by Network Unit Test (Rackspace)
- [x] List Server Addresses by Network Acceptance Test (Rackspace)