### PR TITLE
Adds os-server-groups

### DIFF
--- a/acceptance/openstack/compute/v2/servergroup_test.go
+++ b/acceptance/openstack/compute/v2/servergroup_test.go
@@ -1,0 +1,58 @@
+// +build acceptance compute servers
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/servergroups"
+)
+
+func createServerGroup(t *testing.T, computeClient *gophercloud.ServiceClient) (*servergroups.ServerGroup, error) {
+	sg, err := servergroups.Create(computeClient, &servergroups.CreateOpts{
+		Name:     "test",
+		Policies: []string{"affinity"},
+	}).Extract()
+
+	if err != nil {
+		t.Fatalf("Unable to create server group: %v", err)
+	}
+
+	t.Logf("Created server group: %v", sg.ID)
+	t.Logf("It has policies: %v", sg.Policies)
+
+	return sg, nil
+}
+
+func getServerGroup(t *testing.T, computeClient *gophercloud.ServiceClient, sgID string) error {
+	sg, err := servergroups.Get(computeClient, sgID).Extract()
+	if err != nil {
+		t.Fatalf("Unable to get server group: %v", err)
+	}
+
+	t.Logf("Got server group: %v", sg.Name)
+
+	return nil
+}
+
+func TestServerGroups(t *testing.T) {
+	computeClient, err := newClient()
+	if err != nil {
+		t.Fatalf("Unable to create a compute client: %v", err)
+	}
+
+	sg, err := createServerGroup(t, computeClient)
+	if err != nil {
+		t.Fatalf("Unable to create server group: %v", err)
+	}
+	defer func() {
+		servergroups.Delete(computeClient, sg.ID)
+		t.Logf("ServerGroup deleted.")
+	}()
+
+	err = getServerGroup(t, computeClient, sg.ID)
+	if err != nil {
+		t.Fatalf("Unable to get server group: %v", err)
+	}
+}

--- a/openstack/compute/v2/extensions/servergroups/doc.go
+++ b/openstack/compute/v2/extensions/servergroups/doc.go
@@ -1,0 +1,2 @@
+// Package servergroups provides the ability to manage server groups
+package servergroups

--- a/openstack/compute/v2/extensions/servergroups/fixtures.go
+++ b/openstack/compute/v2/extensions/servergroups/fixtures.go
@@ -1,0 +1,161 @@
+// +build fixtures
+
+package servergroups
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+// ListOutput is a sample response to a List call.
+const ListOutput = `
+{
+    "server_groups": [
+        {
+            "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+            "name": "test",
+            "policies": [
+                "anti-affinity"
+            ],
+            "members": [],
+            "metadata": {}
+        },
+        {
+            "id": "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+            "name": "test2",
+            "policies": [
+                "affinity"
+            ],
+            "members": [],
+            "metadata": {}
+        }
+    ]
+}
+`
+
+// GetOutput is a sample response to a Get call.
+const GetOutput = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
+// CreateOutput is a sample response to a Post call
+const CreateOutput = `
+{
+    "server_group": {
+        "id": "616fb98f-46ca-475e-917e-2563e5a8cd19",
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ],
+        "members": [],
+        "metadata": {}
+    }
+}
+`
+
+// FirstServerGroup is the first result in ListOutput.
+var FirstServerGroup = ServerGroup{
+	ID:   "616fb98f-46ca-475e-917e-2563e5a8cd19",
+	Name: "test",
+	Policies: []string{
+		"anti-affinity",
+	},
+	Members:  []string{},
+	Metadata: map[string]interface{}{},
+}
+
+// SecondServerGroup is the second result in ListOutput.
+var SecondServerGroup = ServerGroup{
+	ID:   "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	Name: "test2",
+	Policies: []string{
+		"affinity",
+	},
+	Members:  []string{},
+	Metadata: map[string]interface{}{},
+}
+
+// ExpectedServerGroupSlice is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedServerGroupSlice = []ServerGroup{FirstServerGroup, SecondServerGroup}
+
+// CreatedServerGroup is the parsed result from CreateOutput.
+var CreatedServerGroup = ServerGroup{
+	ID:   "616fb98f-46ca-475e-917e-2563e5a8cd19",
+	Name: "test",
+	Policies: []string{
+		"anti-affinity",
+	},
+	Members:  []string{},
+	Metadata: map[string]interface{}{},
+}
+
+// HandleListSuccessfully configures the test server to respond to a List request.
+func HandleListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, ListOutput)
+	})
+}
+
+// HandleGetSuccessfully configures the test server to respond to a Get request
+// for an existing server group
+func HandleGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups/4d8c3732-a248-40ed-bebc-539a6ffd25c0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, GetOutput)
+	})
+}
+
+// HandleCreateSuccessfully configures the test server to respond to a Create request
+// for a new server group
+func HandleCreateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+    "server_group": {
+        "name": "test",
+        "policies": [
+            "anti-affinity"
+        ]
+    }
+}
+`)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, CreateOutput)
+	})
+}
+
+// HandleDeleteSuccessfully configures the test server to respond to a Delete request for a
+// an existing server group
+func HandleDeleteSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/os-server-groups/616fb98f-46ca-475e-917e-2563e5a8cd19", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/servergroups/requests.go
+++ b/openstack/compute/v2/extensions/servergroups/requests.go
@@ -1,0 +1,77 @@
+package servergroups
+
+import (
+	"errors"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+// List returns a Pager that allows you to iterate over a collection of ServerGroups.
+func List(client *gophercloud.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return ServerGroupsPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder describes struct types that can be accepted by the Create call. Notably, the
+// CreateOpts struct in this package does.
+type CreateOptsBuilder interface {
+	ToServerGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies a Server Group allocation request
+type CreateOpts struct {
+	// Name is the name of the server group
+	Name string
+
+	// Policies are the server group policies
+	Policies []string
+}
+
+// ToServerGroupCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToServerGroupCreateMap() (map[string]interface{}, error) {
+	if opts.Name == "" {
+		return nil, errors.New("Missing field required for server group creation: Name")
+	}
+
+	if len(opts.Policies) < 1 {
+		return nil, errors.New("Missing field required for server group creation: Policies")
+	}
+
+	serverGroup := make(map[string]interface{})
+	serverGroup["name"] = opts.Name
+	serverGroup["policies"] = opts.Policies
+
+	return map[string]interface{}{"server_group": serverGroup}, nil
+}
+
+// Create requests the creation of a new Server Group
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
+	var res CreateResult
+
+	reqBody, err := opts.ToServerGroupCreateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	_, res.Err = client.Post(createURL(client), reqBody, &res.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return res
+}
+
+// Get returns data about a previously created ServerGroup.
+func Get(client *gophercloud.ServiceClient, id string) GetResult {
+	var res GetResult
+	_, res.Err = client.Get(getURL(client, id), &res.Body, nil)
+	return res
+}
+
+// Delete requests the deletion of a previously allocated ServerGroup.
+func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
+	var res DeleteResult
+	_, res.Err = client.Delete(deleteURL(client, id), nil)
+	return res
+}

--- a/openstack/compute/v2/extensions/servergroups/requests_test.go
+++ b/openstack/compute/v2/extensions/servergroups/requests_test.go
@@ -1,0 +1,59 @@
+package servergroups
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud/pagination"
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListSuccessfully(t)
+
+	count := 0
+	err := List(client.ServiceClient()).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := ExtractServerGroups(page)
+		th.AssertNoErr(t, err)
+		th.CheckDeepEquals(t, ExpectedServerGroupSlice, actual)
+
+		return true, nil
+	})
+	th.AssertNoErr(t, err)
+	th.CheckEquals(t, 1, count)
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateSuccessfully(t)
+
+	actual, err := Create(client.ServiceClient(), CreateOpts{
+		Name:     "test",
+		Policies: []string{"anti-affinity"},
+	}).Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &CreatedServerGroup, actual)
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleGetSuccessfully(t)
+
+	actual, err := Get(client.ServiceClient(), "4d8c3732-a248-40ed-bebc-539a6ffd25c0").Extract()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, &FirstServerGroup, actual)
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDeleteSuccessfully(t)
+
+	err := Delete(client.ServiceClient(), "616fb98f-46ca-475e-917e-2563e5a8cd19").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/extensions/servergroups/results.go
+++ b/openstack/compute/v2/extensions/servergroups/results.go
@@ -1,0 +1,87 @@
+package servergroups
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+// A ServerGroup creates a policy for instance placement in the cloud
+type ServerGroup struct {
+	// ID is the unique ID of the Server Group.
+	ID string `mapstructure:"id"`
+
+	// Name is the common name of the server group.
+	Name string `mapstructure:"name"`
+
+	// Polices are the group policies.
+	Policies []string `mapstructure:"policies"`
+
+	// Members are the members of the server group.
+	Members []string `mapstructure:"members"`
+
+	// Metadata includes a list of all user-specified key-value pairs attached to the Server Group.
+	Metadata map[string]interface{}
+}
+
+// ServerGroupsPage stores a single, only page of ServerGroups
+// results from a List call.
+type ServerGroupsPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a ServerGroupsPage is empty.
+func (page ServerGroupsPage) IsEmpty() (bool, error) {
+	va, err := ExtractServerGroups(page)
+	return len(va) == 0, err
+}
+
+// ExtractServerGroups interprets a page of results as a slice of
+// ServerGroups.
+func ExtractServerGroups(page pagination.Page) ([]ServerGroup, error) {
+	casted := page.(ServerGroupsPage).Body
+	var response struct {
+		ServerGroups []ServerGroup `mapstructure:"server_groups"`
+	}
+
+	err := mapstructure.WeakDecode(casted, &response)
+
+	return response.ServerGroups, err
+}
+
+type ServerGroupResult struct {
+	gophercloud.Result
+}
+
+// Extract is a method that attempts to interpret any Server Group resource
+// response as a ServerGroup struct.
+func (r ServerGroupResult) Extract() (*ServerGroup, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	var res struct {
+		ServerGroup *ServerGroup `json:"server_group" mapstructure:"server_group"`
+	}
+
+	err := mapstructure.WeakDecode(r.Body, &res)
+	return res.ServerGroup, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method to interpret it
+// as a ServerGroup.
+type CreateResult struct {
+	ServerGroupResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to interpret it
+// as a ServerGroup.
+type GetResult struct {
+	ServerGroupResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its Extract method to determine if
+// the call succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/openstack/compute/v2/extensions/servergroups/urls.go
+++ b/openstack/compute/v2/extensions/servergroups/urls.go
@@ -1,0 +1,25 @@
+package servergroups
+
+import "github.com/rackspace/gophercloud"
+
+const resourcePath = "os-server-groups"
+
+func resourceURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return resourceURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return getURL(c, id)
+}

--- a/openstack/compute/v2/extensions/servergroups/urls_test.go
+++ b/openstack/compute/v2/extensions/servergroups/urls_test.go
@@ -1,0 +1,42 @@
+package servergroups
+
+import (
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func TestListURL(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	c := client.ServiceClient()
+
+	th.CheckEquals(t, c.Endpoint+"os-server-groups", listURL(c))
+}
+
+func TestCreateURL(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	c := client.ServiceClient()
+
+	th.CheckEquals(t, c.Endpoint+"os-server-groups", createURL(c))
+}
+
+func TestGetURL(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	c := client.ServiceClient()
+	id := "1"
+
+	th.CheckEquals(t, c.Endpoint+"os-server-groups/"+id, getURL(c, id))
+}
+
+func TestDeleteURL(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	c := client.ServiceClient()
+	id := "1"
+
+	th.CheckEquals(t, c.Endpoint+"os-server-groups/"+id, deleteURL(c, id))
+}


### PR DESCRIPTION
This commit adds support for the os-server-groups extension. This allows
users to create scheduling policies for launching instances.