### PR TITLE
removing line used for debugging

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -169,7 +169,6 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 
 	if options.MoreHeaders != nil {
 		for k, v := range options.MoreHeaders {
-			fmt.Printf("Applying header [%s: %v]\n", k, v)
 			if v != "" {
 				req.Header.Set(k, v)
 			} else {


### PR DESCRIPTION
This solves issue #387.

Removing line https://github.com/rackspace/gophercloud/blob/ea5b3ff6c5b56c0f342dd19e6a7496779b6c2bb0/provider_client.go#L172 which was used for debugging. 