### PR TITLE
fix recursive reauth failure

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -109,6 +109,7 @@ func v2auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 
 	if options.AllowReauth {
 		client.ReauthFunc = func() error {
+			client.TokenID = ""
 			return AuthenticateV2(client, options)
 		}
 	}


### PR DESCRIPTION
If both password and token are specified, token is always used in Identity API v2.
After token was expired, the expired token is used for re-authentication. This fixes recursive re-authetication failure by clearing token before calling reauth method.