### PR TITLE
NetworkExtAttrs bug fix

### DIFF
--- a/openstack/networking/v2/extensions/external/results.go
+++ b/openstack/networking/v2/extensions/external/results.go
@@ -68,7 +68,7 @@ func ExtractUpdate(r networks.UpdateResult) (*NetworkExternal, error) {
 }
 
 // ExtractList accepts a Page struct, specifically a NetworkPage struct, and
-// extracts the elements into a slice of NetworkExtAttrs structs. In other
+// extracts the elements into a slice of NetworkExternal structs. In other
 // words, a generic collection is mapped into a relevant slice.
 func ExtractList(page pagination.Page) ([]NetworkExternal, error) {
 	var resp struct {

--- a/openstack/networking/v2/extensions/provider/results.go
+++ b/openstack/networking/v2/extensions/provider/results.go
@@ -73,7 +73,7 @@ func ExtractGet(r networks.GetResult) (*NetworkExtAttrs, error) {
 		Network *NetworkExtAttrs `json:"network"`
 	}
 
-	err := mapstructure.Decode(r.Body, &res)
+	err := mapstructure.WeakDecode(r.Body, &res)
 
 	return res.Network, err
 }
@@ -89,7 +89,7 @@ func ExtractCreate(r networks.CreateResult) (*NetworkExtAttrs, error) {
 		Network *NetworkExtAttrs `json:"network"`
 	}
 
-	err := mapstructure.Decode(r.Body, &res)
+	err := mapstructure.WeakDecode(r.Body, &res)
 
 	return res.Network, err
 }
@@ -105,7 +105,7 @@ func ExtractUpdate(r networks.UpdateResult) (*NetworkExtAttrs, error) {
 		Network *NetworkExtAttrs `json:"network"`
 	}
 
-	err := mapstructure.Decode(r.Body, &res)
+	err := mapstructure.WeakDecode(r.Body, &res)
 
 	return res.Network, err
 }
@@ -118,7 +118,7 @@ func ExtractList(page pagination.Page) ([]NetworkExtAttrs, error) {
 		Networks []NetworkExtAttrs `mapstructure:"networks" json:"networks"`
 	}
 
-	err := mapstructure.Decode(page.(networks.NetworkPage).Body, &resp)
+	err := mapstructure.WeakDecode(page.(networks.NetworkPage).Body, &resp)
 
 	return resp.Networks, err
 }

--- a/openstack/networking/v2/extensions/provider/results_test.go
+++ b/openstack/networking/v2/extensions/provider/results_test.go
@@ -49,7 +49,7 @@ func TestList(t *testing.T) {
             "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
             "shared": true,
             "id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
-            "provider:segmentation_id": null,
+            "provider:segmentation_id": 1234567890,
             "provider:physical_network": null,
             "provider:network_type": "local"
         }
@@ -91,7 +91,7 @@ func TestList(t *testing.T) {
 				ID:              "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
 				NetworkType:     "local",
 				PhysicalNetwork: "",
-				SegmentationID:  "",
+				SegmentationID:  "1234567890",
 			},
 		}
 


### PR DESCRIPTION
This PR weakly decodes the output from NetworkExt operations to correctly convert types (such as `float64` to `string`).