### PR TITLE
[rfr] Adds Fixed IP support to os-floating-ips

### DIFF
--- a/acceptance/openstack/compute/v2/floatingip_test.go
+++ b/acceptance/openstack/compute/v2/floatingip_test.go
@@ -71,11 +71,11 @@ func associateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, server
 		FloatingIP: fip.IP,
 	}
 
-	err := floatingip.AssociateFloatingIP(client, associateOpts).ExtractErr()
+	err := floatingip.AssociateInstance(client, associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Associated floating IP %v from instance %v", fip.IP, serverId)
 	defer func() {
-		err = floatingip.DisassociateFloatingIP(client, associateOpts).ExtractErr()
+		err = floatingip.DisassociateInstance(client, associateOpts).ExtractErr()
 		th.AssertNoErr(t, err)
 		t.Logf("Disassociated floating IP %v from instance %v", fip.IP, serverId)
 	}()
@@ -108,11 +108,11 @@ func associateFloatingIPFixed(t *testing.T, client *gophercloud.ServiceClient, s
 		FixedIP:    fixedIP,
 	}
 
-	err = floatingip.AssociateFloatingIP(client, associateOpts).ExtractErr()
+	err = floatingip.AssociateInstance(client, associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Associated floating IP %v from instance %v with Fixed IP %v", fip.IP, serverId, fixedIP)
 	defer func() {
-		err = floatingip.DisassociateFloatingIP(client, associateOpts).ExtractErr()
+		err = floatingip.DisassociateInstance(client, associateOpts).ExtractErr()
 		th.AssertNoErr(t, err)
 		t.Logf("Disassociated floating IP %v from instance %v with Fixed IP %v", fip.IP, serverId, fixedIP)
 	}()

--- a/acceptance/openstack/compute/v2/floatingip_test.go
+++ b/acceptance/openstack/compute/v2/floatingip_test.go
@@ -49,7 +49,9 @@ func createFloatingIP(t *testing.T, client *gophercloud.ServiceClient) (*floatin
 	return fip, err
 }
 
-func associateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, serverId string, fip *floatingip.FloatingIP) {
+func associateFloatingIPDeprecated(t *testing.T, client *gophercloud.ServiceClient, serverId string, fip *floatingip.FloatingIP) {
+	// This form works, but is considered deprecated.
+	// See associateFloatingIP or associateFloatingIPFixed
 	err := floatingip.Associate(client, serverId, fip.IP).ExtractErr()
 	th.AssertNoErr(t, err)
 	t.Logf("Associated floating IP %v from instance %v", fip.IP, serverId)
@@ -60,6 +62,63 @@ func associateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, server
 	}()
 	floatingIp, err := floatingip.Get(client, fip.ID).Extract()
 	th.AssertNoErr(t, err)
+	t.Logf("Floating IP %v is associated with Fixed IP %v", fip.IP, floatingIp.FixedIP)
+}
+
+func associateFloatingIP(t *testing.T, client *gophercloud.ServiceClient, serverId string, fip *floatingip.FloatingIP) {
+	associateOpts := floatingip.AssociateOpts{
+		ServerID:   serverId,
+		FloatingIP: fip.IP,
+	}
+
+	err := floatingip.AssociateFloatingIP(client, associateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Associated floating IP %v from instance %v", fip.IP, serverId)
+	defer func() {
+		err = floatingip.DisassociateFloatingIP(client, associateOpts).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Disassociated floating IP %v from instance %v", fip.IP, serverId)
+	}()
+	floatingIp, err := floatingip.Get(client, fip.ID).Extract()
+	th.AssertNoErr(t, err)
+	t.Logf("Floating IP %v is associated with Fixed IP %v", fip.IP, floatingIp.FixedIP)
+}
+
+func associateFloatingIPFixed(t *testing.T, client *gophercloud.ServiceClient, serverId string, fip *floatingip.FloatingIP) {
+
+	network := os.Getenv("OS_NETWORK_NAME")
+	server, err := servers.Get(client, serverId).Extract()
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	var fixedIP string
+	for _, networkAddresses := range server.Addresses[network].([]interface{}) {
+		address := networkAddresses.(map[string]interface{})
+		if address["OS-EXT-IPS:type"] == "fixed" {
+			if address["version"].(float64) == 4 {
+				fixedIP = address["addr"].(string)
+			}
+		}
+	}
+
+	associateOpts := floatingip.AssociateOpts{
+		ServerID:   serverId,
+		FloatingIP: fip.IP,
+		FixedIP:    fixedIP,
+	}
+
+	err = floatingip.AssociateFloatingIP(client, associateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+	t.Logf("Associated floating IP %v from instance %v with Fixed IP %v", fip.IP, serverId, fixedIP)
+	defer func() {
+		err = floatingip.DisassociateFloatingIP(client, associateOpts).ExtractErr()
+		th.AssertNoErr(t, err)
+		t.Logf("Disassociated floating IP %v from instance %v with Fixed IP %v", fip.IP, serverId, fixedIP)
+	}()
+	floatingIp, err := floatingip.Get(client, fip.ID).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, floatingIp.FixedIP, fixedIP)
 	t.Logf("Floating IP %v is associated with Fixed IP %v", fip.IP, floatingIp.FixedIP)
 }
 
@@ -102,6 +161,8 @@ func TestFloatingIP(t *testing.T) {
 		t.Logf("Floating IP deleted.")
 	}()
 
+	associateFloatingIPDeprecated(t, client, server.ID, fip)
 	associateFloatingIP(t, client, server.ID, fip)
+	associateFloatingIPFixed(t, client, server.ID, fip)
 
 }

--- a/openstack/compute/v2/extensions/floatingip/fixtures.go
+++ b/openstack/compute/v2/extensions/floatingip/fixtures.go
@@ -155,6 +155,25 @@ func HandleAssociateSuccessfully(t *testing.T) {
 	})
 }
 
+// HandleFixedAssociateSucessfully configures the test server to respond to a Post request
+// to associate an allocated floating IP with a specific fixed IP address
+func HandleAssociateFixedSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/4d8c3732-a248-40ed-bebc-539a6ffd25c0/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `
+{
+	"addFloatingIp": {
+		"address": "10.10.10.2",
+		"fixed_address": "166.78.185.201"
+	}
+}
+`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
 // HandleDisassociateSuccessfully configures the test server to respond to a Post request
 // to disassociate an allocated floating IP
 func HandleDisassociateSuccessfully(t *testing.T) {

--- a/openstack/compute/v2/extensions/floatingip/requests.go
+++ b/openstack/compute/v2/extensions/floatingip/requests.go
@@ -100,7 +100,7 @@ func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 // association / disassociation
 
 // Associate pairs an allocated floating IP with an instance
-// Deprecated. Use AssociateFloatingIP.
+// Deprecated. Use AssociateInstance.
 func Associate(client *gophercloud.ServiceClient, serverId, fip string) AssociateResult {
 	var res AssociateResult
 
@@ -112,8 +112,8 @@ func Associate(client *gophercloud.ServiceClient, serverId, fip string) Associat
 	return res
 }
 
-// AssociateFloatingIP pairs an allocated floating IP with an instance.
-func AssociateFloatingIP(client *gophercloud.ServiceClient, opts AssociateOpts) AssociateResult {
+// AssociateInstance pairs an allocated floating IP with an instance.
+func AssociateInstance(client *gophercloud.ServiceClient, opts AssociateOpts) AssociateResult {
 	var res AssociateResult
 
 	associateInfo, err := opts.ToAssociateMap()
@@ -138,7 +138,7 @@ func AssociateFloatingIP(client *gophercloud.ServiceClient, opts AssociateOpts) 
 }
 
 // Disassociate decouples an allocated floating IP from an instance
-// Deprecated. Use DisassociateFloatingIP.
+// Deprecated. Use DisassociateInstance.
 func Disassociate(client *gophercloud.ServiceClient, serverId, fip string) DisassociateResult {
 	var res DisassociateResult
 
@@ -150,8 +150,8 @@ func Disassociate(client *gophercloud.ServiceClient, serverId, fip string) Disas
 	return res
 }
 
-// DisassociateFloatingIP decouples an allocated floating IP from an instance
-func DisassociateFloatingIP(client *gophercloud.ServiceClient, opts AssociateOpts) DisassociateResult {
+// DisassociateInstance decouples an allocated floating IP from an instance
+func DisassociateInstance(client *gophercloud.ServiceClient, opts AssociateOpts) DisassociateResult {
 	var res DisassociateResult
 
 	associateInfo, err := opts.ToAssociateMap()

--- a/openstack/compute/v2/extensions/floatingip/requests.go
+++ b/openstack/compute/v2/extensions/floatingip/requests.go
@@ -26,6 +26,18 @@ type CreateOpts struct {
 	Pool string
 }
 
+// AssociateOpts specifies the required information to associate or disassociate a floating IP to an instance
+type AssociateOpts struct {
+	// ServerID is the UUID of the server
+	ServerID string
+
+	// FixedIP is an optional fixed IP address of the server
+	FixedIP string
+
+	// FloatingIP is the floating IP to associate with an instance
+	FloatingIP string
+}
+
 // ToFloatingIPCreateMap constructs a request body from CreateOpts.
 func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
 	if opts.Pool == "" {
@@ -33,6 +45,26 @@ func (opts CreateOpts) ToFloatingIPCreateMap() (map[string]interface{}, error) {
 	}
 
 	return map[string]interface{}{"pool": opts.Pool}, nil
+}
+
+// ToAssociateMap constructs a request body from AssociateOpts.
+func (opts AssociateOpts) ToAssociateMap() (map[string]interface{}, error) {
+	if opts.ServerID == "" {
+		return nil, errors.New("Required field missing for floating IP association: ServerID")
+	}
+
+	if opts.FloatingIP == "" {
+		return nil, errors.New("Required field missing for floating IP association: FloatingIP")
+	}
+
+	associateInfo := map[string]interface{}{
+		"serverId":   opts.ServerID,
+		"floatingIp": opts.FloatingIP,
+		"fixedIp":    opts.FixedIP,
+	}
+
+	return associateInfo, nil
+
 }
 
 // Create requests the creation of a new floating IP
@@ -68,6 +100,7 @@ func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
 // association / disassociation
 
 // Associate pairs an allocated floating IP with an instance
+// Deprecated. Use AssociateFloatingIP.
 func Associate(client *gophercloud.ServiceClient, serverId, fip string) AssociateResult {
 	var res AssociateResult
 
@@ -79,13 +112,59 @@ func Associate(client *gophercloud.ServiceClient, serverId, fip string) Associat
 	return res
 }
 
+// AssociateFloatingIP pairs an allocated floating IP with an instance.
+func AssociateFloatingIP(client *gophercloud.ServiceClient, opts AssociateOpts) AssociateResult {
+	var res AssociateResult
+
+	associateInfo, err := opts.ToAssociateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	addFloatingIp := make(map[string]interface{})
+	addFloatingIp["address"] = associateInfo["floatingIp"].(string)
+
+	// fixedIp is not required
+	if associateInfo["fixedIp"] != "" {
+		addFloatingIp["fixed_address"] = associateInfo["fixedIp"].(string)
+	}
+
+	serverId := associateInfo["serverId"].(string)
+
+	reqBody := map[string]interface{}{"addFloatingIp": addFloatingIp}
+	_, res.Err = client.Post(associateURL(client, serverId), reqBody, nil, nil)
+	return res
+}
+
 // Disassociate decouples an allocated floating IP from an instance
+// Deprecated. Use DisassociateFloatingIP.
 func Disassociate(client *gophercloud.ServiceClient, serverId, fip string) DisassociateResult {
 	var res DisassociateResult
 
 	removeFloatingIp := make(map[string]interface{})
 	removeFloatingIp["address"] = fip
 	reqBody := map[string]interface{}{"removeFloatingIp": removeFloatingIp}
+
+	_, res.Err = client.Post(disassociateURL(client, serverId), reqBody, nil, nil)
+	return res
+}
+
+// DisassociateFloatingIP decouples an allocated floating IP from an instance
+func DisassociateFloatingIP(client *gophercloud.ServiceClient, opts AssociateOpts) DisassociateResult {
+	var res DisassociateResult
+
+	associateInfo, err := opts.ToAssociateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	removeFloatingIp := make(map[string]interface{})
+	removeFloatingIp["address"] = associateInfo["floatingIp"].(string)
+	reqBody := map[string]interface{}{"removeFloatingIp": removeFloatingIp}
+
+	serverId := associateInfo["serverId"].(string)
 
 	_, res.Err = client.Post(disassociateURL(client, serverId), reqBody, nil, nil)
 	return res

--- a/openstack/compute/v2/extensions/floatingip/requests_test.go
+++ b/openstack/compute/v2/extensions/floatingip/requests_test.go
@@ -57,7 +57,7 @@ func TestDelete(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestAssociate(t *testing.T) {
+func TestAssociateDeprecated(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleAssociateSuccessfully(t)
@@ -68,7 +68,36 @@ func TestAssociate(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestDisassociate(t *testing.T) {
+func TestAssociate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAssociateSuccessfully(t)
+
+	associateOpts := AssociateOpts{
+		ServerID:   "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+		FloatingIP: "10.10.10.2",
+	}
+
+	err := AssociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestAssociateFixed(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleAssociateFixedSuccessfully(t)
+
+	associateOpts := AssociateOpts{
+		ServerID:   "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+		FloatingIP: "10.10.10.2",
+		FixedIP:    "166.78.185.201",
+	}
+
+	err := AssociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDisassociateDeprecated(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleDisassociateSuccessfully(t)
@@ -76,5 +105,19 @@ func TestDisassociate(t *testing.T) {
 	fip := "10.10.10.2"
 
 	err := Disassociate(client.ServiceClient(), serverId, fip).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestDisassociateFloatingIP(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleDisassociateSuccessfully(t)
+
+	associateOpts := AssociateOpts{
+		ServerID:   "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+		FloatingIP: "10.10.10.2",
+	}
+
+	err := DisassociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }

--- a/openstack/compute/v2/extensions/floatingip/requests_test.go
+++ b/openstack/compute/v2/extensions/floatingip/requests_test.go
@@ -78,7 +78,7 @@ func TestAssociate(t *testing.T) {
 		FloatingIP: "10.10.10.2",
 	}
 
-	err := AssociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
+	err := AssociateInstance(client.ServiceClient(), associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 
@@ -93,7 +93,7 @@ func TestAssociateFixed(t *testing.T) {
 		FixedIP:    "166.78.185.201",
 	}
 
-	err := AssociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
+	err := AssociateInstance(client.ServiceClient(), associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }
 
@@ -108,7 +108,7 @@ func TestDisassociateDeprecated(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
-func TestDisassociateFloatingIP(t *testing.T) {
+func TestDisassociateInstance(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleDisassociateSuccessfully(t)
@@ -118,6 +118,6 @@ func TestDisassociateFloatingIP(t *testing.T) {
 		FloatingIP: "10.10.10.2",
 	}
 
-	err := DisassociateFloatingIP(client.ServiceClient(), associateOpts).ExtractErr()
+	err := DisassociateInstance(client.ServiceClient(), associateOpts).ExtractErr()
 	th.AssertNoErr(t, err)
 }


### PR DESCRIPTION
This commit enables the ability to specify a fixed IP when associating a
floating IP to an instance. If a fixed IP is not specified, Nova will
attempt to associate the floating IP to the first detected fixed IP, as it
did prior to this patch.