### PR TITLE
ssh key name can be sent during server creation

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -131,6 +131,9 @@ type CreateOpts struct {
 
 	// ConfigDrive [optional] enables metadata injection through a configuration drive.
 	ConfigDrive bool
+
+	// KeyPair [optional] specifies an key pair for the instance for authentication 
+	KeyPairName string
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -181,6 +184,10 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 			}
 		}
 		server["networks"] = networks
+	}
+
+	if opts.KeyPairName != "" {
+		server["key_name"] = opts.KeyPairName
 	}
 
 	return map[string]interface{}{"server": server}, nil


### PR DESCRIPTION
Looks like the `CreateOpts` for `openstack/compute/v2/servers` was missing a key pair name. Users should be able to easily supply the name of an exiting key during creation.

This is maybe not surprising since it's not documented :
https://bugs.launchpad.net/openstack-api-site/+bug/1300870