### PR TITLE
Updating paths from code.google.com/p/* to golang.org/x/*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - tip
 script: script/cibuild
 after_success:
-  - go get code.google.com/p/go.tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - export PATH=$PATH:$HOME/gopath/bin/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export GOPATH=$HOME/go
 ```
 
 To protect yourself against changes in your dependencies, we highly recommend choosing a
-[dependency management solution](https://code.google.com/p/go-wiki/wiki/PackageManagementTools) for
+[dependency management solution](https://github.com/golang/go/wiki/PackageManagementTools) for
 your projects, such as [godep](https://github.com/tools/godep). Once this is set up, you can install
 Gophercloud as a dependency like so:
 

--- a/acceptance/openstack/compute/v2/keypairs_test.go
+++ b/acceptance/openstack/compute/v2/keypairs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	th "github.com/rackspace/gophercloud/testhelper"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 )
 
 const keyName = "gophercloud_test_key_pair"


### PR DESCRIPTION
Hi, 

Quick comment.

As I was dealing with some dependency management in `gophercloud` earlier this week, I noticed that one of the test files is still utilizing `code.google.com/p/go.crypto` instead of `golang.org/x/crypto`.  

As everyone is this project is probably aware, the golang team has moved these dependencies from `code.google.com/p/*` to `golang.org/x/*`.  You can find the google groups announcement here: https://groups.google.com/forum/#!topic/golang-nuts/eD8dh3T9yyA

If we can switch over to `golang.org/x/` I would propose we do so.  It would help people like me who are dealing with their own golang dependency management and are now expecting the new import paths.

Thanks! 