### PR TITLE
feature - added ability to retreive any attached volume from an instance

### DIFF
--- a/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/openstack/compute/v2/extensions/volumeattach/results.go
@@ -65,6 +65,22 @@ func (r VolumeAttachmentResult) Extract() (*VolumeAttachment, error) {
 	return res.VolumeAttachment, err
 }
 
+// ExtractAll is a method that attempts to interpret any VolumeAttachment resources
+// response as a slice of VolumeAttachment struct.  This differs from Extract when
+// calling Get without a volume ID and results are less than a page.
+func (r VolumeAttachmentResult) ExtractAll() ([]*VolumeAttachment, error) {
+        if r.Err != nil {
+                return nil, r.Err
+        }
+
+        var res struct {
+                VolumeAttachments []*VolumeAttachment `json:"volumeAttachments" mapstructure:"volumeAttachments"`
+        }
+
+        err := mapstructure.Decode(r.Body, &res)
+        return res.VolumeAttachments, err
+}
+
 // CreateResult is the response from a Create operation. Call its Extract method to interpret it
 // as a VolumeAttachment.
 type CreateResult struct {

--- a/openstack/compute/v2/extensions/volumeattach/urls.go
+++ b/openstack/compute/v2/extensions/volumeattach/urls.go
@@ -17,7 +17,11 @@ func createURL(c *gophercloud.ServiceClient, serverId string) string {
 }
 
 func getURL(c *gophercloud.ServiceClient, serverId, aId string) string {
-	return c.ServiceURL("servers", serverId, resourcePath, aId)
+	if aId == "" {
+		return c.ServiceURL("servers", serverId, resourcePath)
+	} else {
+		return c.ServiceURL("servers", serverId, resourcePath, aId)
+	}
 }
 
 func deleteURL(c *gophercloud.ServiceClient, serverId, aId string) string {


### PR DESCRIPTION
When doing a Get request on attached volumes of an instance, it was previously required that you enter a volume ID.  These small changes allow you to not specify a volume ID, and return a proper list of currently attached volumes.