### PR TITLE
Server actions : CreateImage

### DIFF
--- a/openstack/compute/v2/servers/fixtures.go
+++ b/openstack/compute/v2/servers/fixtures.go
@@ -651,3 +651,12 @@ func HandleNetworkAddressListSuccessfully(t *testing.T) {
 			}`)
 	})
 }
+
+func HandleCreateServerImageSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/asdfasdfasdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -14,7 +14,6 @@ import (
 type ListOptsBuilder interface {
 	ToServerListQuery() (string, error)
 }
-
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Filtering is achieved by passing in struct field values that map to
 // the server attributes you want to see returned. Marker and Limit are used
@@ -700,4 +699,43 @@ func ListAddressesByNetwork(client *gophercloud.ServiceClient, id, network strin
 		return NetworkAddressPage{pagination.SinglePageBase(r)}
 	}
 	return pagination.NewPager(client, listAddressesByNetworkURL(client, id, network), createPageFn)
+}
+
+type CreateServerImageOpts struct {
+	// Name [required] of the image/snapshot
+	Name string
+	// Metadata [optional] contains key-value pairs (up to 255 bytes each) to attach to the created image.
+	Metadata map[string]string
+}
+
+type CreateServerImageOptsBuilder interface {
+	ToCreateServerImageMap() (map[string]interface{}, error)
+}
+
+// ToServerImageCreateMap formats an ServerImageCreateOpts structure into a request body.
+func (opts CreateServerImageOpts) ToCreateServerImageMap() (map[string]interface{}, error) {
+	var err error
+	img := make(map[string]interface{})
+	if opts.Name == "" {
+		err = fmt.Errorf("Cannot create a server image without a name")
+	}
+	img["name"] = opts.Name
+	if opts.Metadata != nil {
+		img["metadata"] = opts.Metadata
+	}
+	createImage := make(map[string]interface{})
+	createImage["createImage"] = img
+	return createImage, err
+}
+
+// CreateServerImage makes a request against the nova API to schedule an image to be created of the server
+func CreateServerImage(client *gophercloud.ServiceClient, serverId string, opts CreateServerImageOptsBuilder) CreateServerImageResult {
+	var res CreateServerImageResult
+	reqBody, err := opts.ToCreateServerImageMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	_, res.Err = client.Post(actionURL(client, serverId), reqBody, &res.Body, nil)
+	return res
 }

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -325,3 +325,12 @@ func TestListAddressesByNetwork(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, 1, pages)
 }
+
+func TestCreateServerImage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateServerImageSuccessfully(t)
+	
+	err := CreateServerImage(client.ServiceClient(), "1234asdf", CreateServerImageOpts{Name: "test"}).ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -74,6 +74,11 @@ type RescueResult struct {
 	ActionResult
 }
 
+// RescueResult represents the result of a server rescue operation
+type CreateServerImageResult struct {
+	gophercloud.ErrResult
+}
+
 // Extract interprets any RescueResult as an AdminPass, if possible.
 func (r RescueResult) Extract() (string, error) {
 	if r.Err != nil {

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -76,7 +76,7 @@ type RescueResult struct {
 
 // RescueResult represents the result of a server rescue operation
 type CreateServerImageResult struct {
-	gophercloud.ErrResult
+	gophercloud.Result
 }
 
 // Extract interprets any RescueResult as an AdminPass, if possible.


### PR DESCRIPTION
A server action for creation a sever image was missing. This is identical to how the standard openstack client operates when doing a "server image create". Might be a bit quick and dirty right now, but works.

Need something like this to get proper gophercloud support in the Packer project.