### PR TITLE
server action to create a server image / snapshot

### DIFF
--- a/openstack/compute/v2/servers/fixtures.go
+++ b/openstack/compute/v2/servers/fixtures.go
@@ -651,3 +651,14 @@ func HandleNetworkAddressListSuccessfully(t *testing.T) {
 			}`)
 	})
 }
+
+// HandleCreateServerImageSuccessfully sets up the test server to respond to a TestCreateServerImage request.
+func HandleCreateServerImageSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/servers/serverimage/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Location", "https://0.0.0.0/images/xxxx-xxxxx-xxxxx-xxxx")
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -331,7 +331,6 @@ func TestCreateServerImage(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleCreateServerImageSuccessfully(t)
 
-	_, err := CreateServerImage(client.ServiceClient(), "serverimage", CreateServerImageOpts{Name: "test"}).ExtractImageID()
+	_, err := CreateImage(client.ServiceClient(), "serverimage", CreateImageOpts{Name: "test"}).ExtractImageID()
 	th.AssertNoErr(t, err)
-	
 }

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -325,3 +325,13 @@ func TestListAddressesByNetwork(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, 1, pages)
 }
+
+func TestCreateServerImage(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleCreateServerImageSuccessfully(t)
+
+	_, err := CreateServerImage(client.ServiceClient(), "serverimage", CreateServerImageOpts{Name: "test"}).ExtractImageID()
+	th.AssertNoErr(t, err)
+	
+}

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -74,6 +74,11 @@ type RescueResult struct {
 	ActionResult
 }
 
+// RescueResult represents the result of a server rescue operation
+type CreateServerImageResult struct {
+	gophercloud.Result
+}
+
 // Extract interprets any RescueResult as an AdminPass, if possible.
 func (r RescueResult) Extract() (string, error) {
 	if r.Err != nil {

--- a/openstack/compute/v2/servers/results.go
+++ b/openstack/compute/v2/servers/results.go
@@ -2,6 +2,9 @@ package servers
 
 import (
 	"reflect"
+	"fmt"
+	"path"
+	"net/url"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rackspace/gophercloud"
@@ -74,9 +77,26 @@ type RescueResult struct {
 	ActionResult
 }
 
-// RescueResult represents the result of a server rescue operation
-type CreateServerImageResult struct {
+// CreateImageResult represents the result of an image creation operation
+type CreateImageResult struct {
 	gophercloud.Result
+}
+
+// ExtractImageID gets the ID of the newly created server image from the header
+func (res CreateImageResult) ExtractImageID() (string, error) {
+	if res.Err != nil {
+		return "", res.Err
+	}
+	// Get the image id from the header
+	u, err := url.ParseRequestURI(res.Header.Get("Location"))
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse the image id: %s", err.Error())
+	}
+	imageId := path.Base(u.Path)
+	if imageId == "." || imageId == "/" {
+		return "", fmt.Errorf("Failed to parse the ID of newly created image: %s", u)
+	}
+	return imageId, nil
 }
 
 // Extract interprets any RescueResult as an AdminPass, if possible.


### PR DESCRIPTION
Missing this server action to create a snapshot/image from a server. This is identical to what the openstack client does after a `server image create`.