### PR TITLE
Use a ReadSeeker for upload content and rewind the offset on retries

### DIFF
--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -188,7 +188,7 @@ func (opts CreateOpts) ToObjectCreateParams() (map[string]string, string, error)
 }
 
 // Create is a function that creates a new object or replaces an existing object.
-func Create(c *gophercloud.ServiceClient, containerName, objectName string, content io.Reader, opts CreateOptsBuilder) CreateResult {
+func Create(c *gophercloud.ServiceClient, containerName, objectName string, content io.ReadSeeker, opts CreateOptsBuilder) CreateResult {
 	var res CreateResult
 
 	url := createURL(c, containerName, objectName)

--- a/openstack/objectstorage/v1/objects/requests_test.go
+++ b/openstack/objectstorage/v1/objects/requests_test.go
@@ -3,6 +3,7 @@ package objects
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/rackspace/gophercloud/pagination"
@@ -85,7 +86,7 @@ func TestCreateObject(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleCreateTextObjectSuccessfully(t)
 
-	content := bytes.NewBufferString("Did gyre and gimble in the wabe")
+	content := strings.NewReader("Did gyre and gimble in the wabe")
 	options := &CreateOpts{ContentType: "text/plain"}
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, options)
 	th.AssertNoErr(t, res.Err)
@@ -96,7 +97,7 @@ func TestCreateObjectWithoutContentType(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleCreateTypelessObjectSuccessfully(t)
 
-	content := bytes.NewBufferString("The sky was the color of television, tuned to a dead channel.")
+	content := strings.NewReader("The sky was the color of television, tuned to a dead channel.")
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &CreateOpts{})
 	th.AssertNoErr(t, res.Err)
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -85,9 +85,9 @@ type RequestOpts struct {
 	// content type of the request will default to "application/json" unless overridden by MoreHeaders.
 	// It's an error to specify both a JSONBody and a RawBody.
 	JSONBody interface{}
-	// RawBody contains an io.Reader that will be consumed by the request directly. No content-type
+	// RawBody contains an io.ReadSeeker that will be consumed by the request directly. No content-type
 	// will be set unless one is provided explicitly by MoreHeaders.
-	RawBody io.Reader
+	RawBody io.ReadSeeker
 
 	// JSONResponse, if provided, will be populated with the contents of the response body parsed as
 	// JSON.
@@ -124,11 +124,11 @@ var applicationJSON = "application/json"
 // Request performs an HTTP request using the ProviderClient's current HTTPClient. An authentication
 // header will automatically be provided.
 func (client *ProviderClient) Request(method, url string, options RequestOpts) (*http.Response, error) {
-	var body io.Reader
+	var body io.ReadSeeker
 	var contentType *string
 
 	// Derive the content body by either encoding an arbitrary object as JSON, or by taking a provided
-	// io.Reader as-is. Default the content-type to application/json.
+	// io.ReadSeeker as-is. Default the content-type to application/json.
 	if options.JSONBody != nil {
 		if options.RawBody != nil {
 			panic("Please provide only one of JSONBody or RawBody to gophercloud.Request().")
@@ -189,6 +189,7 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 			if err != nil {
 				return nil, fmt.Errorf("Error trying to re-authenticate: %s", err)
 			}
+			options.RawBody.Seek(0, 0)
 			resp, err = client.Request(method, url, options)
 			if err != nil {
 				return nil, fmt.Errorf("Successfully re-authenticated, but got error executing request: %s", err)
@@ -260,7 +261,7 @@ func (client *ProviderClient) Post(url string, JSONBody interface{}, JSONRespons
 		opts = &RequestOpts{}
 	}
 
-	if v, ok := (JSONBody).(io.Reader); ok {
+	if v, ok := (JSONBody).(io.ReadSeeker); ok {
 		opts.RawBody = v
 	} else if JSONBody != nil {
 		opts.JSONBody = JSONBody
@@ -278,7 +279,7 @@ func (client *ProviderClient) Put(url string, JSONBody interface{}, JSONResponse
 		opts = &RequestOpts{}
 	}
 
-	if v, ok := (JSONBody).(io.Reader); ok {
+	if v, ok := (JSONBody).(io.ReadSeeker); ok {
 		opts.RawBody = v
 	} else if JSONBody != nil {
 		opts.JSONBody = JSONBody

--- a/rackspace/objectstorage/v1/objects/delegate.go
+++ b/rackspace/objectstorage/v1/objects/delegate.go
@@ -33,7 +33,7 @@ func Download(c *gophercloud.ServiceClient, containerName, objectName string, op
 }
 
 // Create is a function that creates a new object or replaces an existing object.
-func Create(c *gophercloud.ServiceClient, containerName, objectName string, content io.Reader, opts os.CreateOptsBuilder) os.CreateResult {
+func Create(c *gophercloud.ServiceClient, containerName, objectName string, content io.ReadSeeker, opts os.CreateOptsBuilder) os.CreateResult {
 	return os.Create(c, containerName, objectName, content, opts)
 }
 

--- a/rackspace/objectstorage/v1/objects/delegate_test.go
+++ b/rackspace/objectstorage/v1/objects/delegate_test.go
@@ -1,7 +1,7 @@
 package objects
 
 import (
-	"bytes"
+	"strings"
 	"testing"
 
 	os "github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
@@ -68,7 +68,7 @@ func TestCreateObject(t *testing.T) {
 	defer th.TeardownHTTP()
 	os.HandleCreateTextObjectSuccessfully(t)
 
-	content := bytes.NewBufferString("Did gyre and gimble in the wabe")
+	content := strings.NewReader("Did gyre and gimble in the wabe")
 	options := &os.CreateOpts{ContentType: "text/plain"}
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, options)
 	th.AssertNoErr(t, res.Err)
@@ -79,7 +79,7 @@ func TestCreateObjectWithoutContentType(t *testing.T) {
 	defer th.TeardownHTTP()
 	os.HandleCreateTypelessObjectSuccessfully(t)
 
-	content := bytes.NewBufferString("The sky was the color of television, tuned to a dead channel.")
+	content := strings.NewReader("The sky was the color of television, tuned to a dead channel.")
 	res := Create(fake.ServiceClient(), "testContainer", "testObject", content, &os.CreateOpts{})
 	th.AssertNoErr(t, res.Err)
 }


### PR DESCRIPTION
I have an issue where if a re-authentication is required during a object upload that object is eventually created with no content. Here are the Cloud Files access logs from one failed upload. The initial response is a 401 unauthorized. The client then re-authenticates and successfully retries the request but silently fails to include the file content.

```
209.61.148.41 - - [27/04/2015:11:06:51 +0000] "PUT /v1/[redacted]/events-1430043166780366665.gz HTTP/1.0" 401 131 "-" "gophercloud/v1.0"
209.61.148.41 - - [27/04/2015:11:06:52 +0000] "PUT /v1/[redacted]/events-1430043166780366665.gz HTTP/1.0" 201 0 "-" "gophercloud/v1.0"
```

I believe the second time the request is called the `io.Reader` `options.RawBody` has no un-read content. Unfortunately the offset in `io.Reader` cant be rewound AFAIK. This PR resolves the issue by changing `options.RawBody` to a `io.ReadSeeker` and resetting the offset before re-trying requests.