### PR TITLE
fix object storage nil pointer dereference error; Closes #427

### DIFF
--- a/openstack/objectstorage/v1/accounts/requests.go
+++ b/openstack/objectstorage/v1/accounts/requests.go
@@ -43,7 +43,9 @@ func Get(c *gophercloud.ServiceClient, opts GetOptsBuilder) GetResult {
 		MoreHeaders: h,
 		OkCodes:     []int{204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -97,7 +99,9 @@ func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) UpdateResult {
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }

--- a/openstack/objectstorage/v1/containers/requests.go
+++ b/openstack/objectstorage/v1/containers/requests.go
@@ -114,7 +114,9 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -180,7 +182,9 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -193,7 +197,9 @@ func Get(c *gophercloud.ServiceClient, containerName string) GetResult {
 	resp, err := c.Request("HEAD", getURL(c, containerName), gophercloud.RequestOpts{
 		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -134,10 +134,11 @@ func Download(c *gophercloud.ServiceClient, containerName, objectName string, op
 		MoreHeaders: h,
 		OkCodes:     []int{200, 304},
 	})
-
-	res.Body = resp.Body
+	if resp != nil {
+		res.Header = resp.Header
+		res.Body = resp.Body
+	}
 	res.Err = err
-	res.Header = resp.Header
 
 	return res
 }
@@ -214,7 +215,9 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 	}
 
 	resp, err := c.Request("PUT", url, ropts)
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -270,7 +273,9 @@ func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts C
 		MoreHeaders: h,
 		OkCodes:     []int{201},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -310,7 +315,9 @@ func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts
 	}
 
 	resp, err := c.Delete(url, nil)
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -354,7 +361,9 @@ func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts Ge
 	resp, err := c.Request("HEAD", url, gophercloud.RequestOpts{
 		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -410,7 +419,9 @@ func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts
 	resp, err := c.Request("POST", url, gophercloud.RequestOpts{
 		MoreHeaders: h,
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }

--- a/rackspace/objectstorage/v1/bulk/requests.go
+++ b/rackspace/objectstorage/v1/bulk/requests.go
@@ -43,7 +43,9 @@ func Delete(c *gophercloud.ServiceClient, opts DeleteOptsBuilder) DeleteResult {
 		JSONBody:     reqBody,
 		JSONResponse: &res.Body,
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }

--- a/rackspace/objectstorage/v1/cdncontainers/requests.go
+++ b/rackspace/objectstorage/v1/cdncontainers/requests.go
@@ -53,7 +53,9 @@ func Enable(c *gophercloud.ServiceClient, containerName string, opts EnableOptsB
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -66,7 +68,9 @@ func Get(c *gophercloud.ServiceClient, containerName string) GetResult {
 	resp, err := c.Request("HEAD", getURL(c, containerName), gophercloud.RequestOpts{
 		OkCodes: []int{200, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }
@@ -149,7 +153,9 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 		MoreHeaders: h,
 		OkCodes:     []int{202, 204},
 	})
-	res.Header = resp.Header
+	if resp != nil {
+		res.Header = resp.Header
+	}
 	res.Err = err
 	return res
 }


### PR DESCRIPTION
If a request errors out, then the `resp` returned from the `gophercloud.Request` method will be `nil`. In that case, trying to access the `Header` field will fail. This PR tries to fix that.