### PR TITLE
create server helper fields

### DIFF
--- a/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
@@ -32,6 +32,8 @@ func TestCreateOpts(t *testing.T) {
         "name": "createdserver",
         "imageRef": "asdfasdfasdf",
         "flavorRef": "performance1-1",
+				"flavorName": "",
+				"imageName": "",
         "block_device_mapping_v2":[
           {
             "uuid":"123456",

--- a/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
@@ -32,8 +32,8 @@ func TestCreateOpts(t *testing.T) {
         "name": "createdserver",
         "imageRef": "asdfasdfasdf",
         "flavorRef": "performance1-1",
-				"flavorName": "",
-				"imageName": "",
+	"flavorName": "",
+	"imageName": "",
         "block_device_mapping_v2":[
           {
             "uuid":"123456",

--- a/openstack/compute/v2/extensions/diskconfig/requests_test.go
+++ b/openstack/compute/v2/extensions/diskconfig/requests_test.go
@@ -25,6 +25,8 @@ func TestCreateOpts(t *testing.T) {
 				"name": "createdserver",
 				"imageRef": "asdfasdfasdf",
 				"flavorRef": "performance1-1",
+				"flavorName": "",
+				"imageName": "",
 				"OS-DCF:diskConfig": "MANUAL"
 			}
 		}

--- a/openstack/compute/v2/extensions/schedulerhints/requests_test.go
+++ b/openstack/compute/v2/extensions/schedulerhints/requests_test.go
@@ -39,7 +39,9 @@ func TestCreateOpts(t *testing.T) {
 			"server": {
 				"name": "createdserver",
 				"imageRef": "asdfasdfasdf",
-				"flavorRef": "performance1-1"
+				"flavorRef": "performance1-1",
+				"flavorName": "",
+				"imageName": ""
 			},
 			"os:scheduler_hints": {
 				"group": "101aed42-22d9-4a3e-9ba1-21103b0d1aba",
@@ -97,7 +99,9 @@ func TestCreateOptsWithComplexQuery(t *testing.T) {
 			"server": {
 				"name": "createdserver",
 				"imageRef": "asdfasdfasdf",
-				"flavorRef": "performance1-1"
+				"flavorRef": "performance1-1",
+				"flavorName": "",
+				"imageName": ""
 			},
 			"os:scheduler_hints": {
 				"group": "101aed42-22d9-4a3e-9ba1-21103b0d1aba",

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/images"
 	"github.com/rackspace/gophercloud/pagination"
 )
 
@@ -127,12 +129,23 @@ type CreateOpts struct {
 	// Name [required] is the name to assign to the newly launched server.
 	Name string
 
-	// ImageRef [required] is the ID or full URL to the image that contains the server's OS and initial state.
-	// Optional if using the boot-from-volume extension.
+	// ImageRef [optional; required if ImageName is not provided] is the ID or full
+	// URL to the image that contains the server's OS and initial state.
+	// Also optional if using the boot-from-volume extension.
 	ImageRef string
 
-	// FlavorRef [required] is the ID or full URL to the flavor that describes the server's specs.
+	// ImageName [optional; required if ImageRef is not provided] is the name of the
+	// image that contains the server's OS and initial state.
+	// Also optional if using the boot-from-volume extension.
+	ImageName string
+
+	// FlavorRef [optional; required if FlavorName is not provided] is the ID or
+	// full URL to the flavor that describes the server's specs.
 	FlavorRef string
+
+	// FlavorName [optional; required if FlavorRef is not provided] is the name of
+	// the flavor that describes the server's specs.
+	FlavorName string
 
 	// SecurityGroups [optional] lists the names of the security groups to which this server should belong.
 	SecurityGroups []string
@@ -175,7 +188,9 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 
 	server["name"] = opts.Name
 	server["imageRef"] = opts.ImageRef
+	server["imageName"] = opts.ImageName
 	server["flavorRef"] = opts.FlavorRef
+	server["flavorName"] = opts.FlavorName
 
 	if opts.UserData != nil {
 		encoded := base64.StdEncoding.EncodeToString(opts.UserData)
@@ -241,6 +256,38 @@ func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateRes
 		res.Err = err
 		return res
 	}
+
+	// If ImageRef isn't provided, use ImageName to ascertain the image ID.
+	if reqBody["server"].(map[string]interface{})["imageRef"].(string) == "" {
+		imageName := reqBody["server"].(map[string]interface{})["imageName"].(string)
+		if imageName == "" {
+			res.Err = errors.New("One and only one of ImageRef and ImageName must be provided.")
+			return res
+		}
+		imageID, err := images.IDFromName(client, imageName)
+		if err != nil {
+			res.Err = err
+			return res
+		}
+		reqBody["server"].(map[string]interface{})["imageRef"] = imageID
+	}
+	delete(reqBody["server"].(map[string]interface{}), "imageName")
+
+	// If FlavorRef isn't provided, use FlavorName to ascertain the flavor ID.
+	if reqBody["server"].(map[string]interface{})["flavorRef"].(string) == "" {
+		flavorName := reqBody["server"].(map[string]interface{})["flavorName"].(string)
+		if flavorName == "" {
+			res.Err = errors.New("One and only one of FlavorRef and FlavorName must be provided.")
+			return res
+		}
+		flavorID, err := flavors.IDFromName(client, flavorName)
+		if err != nil {
+			res.Err = err
+			return res
+		}
+		reqBody["server"].(map[string]interface{})["flavorRef"] = flavorID
+	}
+	delete(reqBody["server"].(map[string]interface{}), "flavorName")
 
 	_, res.Err = client.Post(listURL(client), reqBody, &res.Body, nil)
 	return res

--- a/rackspace/compute/v2/bootfromvolume/delegate_test.go
+++ b/rackspace/compute/v2/bootfromvolume/delegate_test.go
@@ -33,6 +33,8 @@ func TestCreateOpts(t *testing.T) {
         "name": "createdserver",
         "imageRef": "asdfasdfasdf",
         "flavorRef": "performance1-1",
+				"flavorName": "",
+				"imageName": "",
         "block_device_mapping_v2":[
           {
             "uuid":"123456",

--- a/rackspace/compute/v2/bootfromvolume/delegate_test.go
+++ b/rackspace/compute/v2/bootfromvolume/delegate_test.go
@@ -33,8 +33,8 @@ func TestCreateOpts(t *testing.T) {
         "name": "createdserver",
         "imageRef": "asdfasdfasdf",
         "flavorRef": "performance1-1",
-				"flavorName": "",
-				"imageName": "",
+	"flavorName": "",
+	"imageName": "",
         "block_device_mapping_v2":[
           {
             "uuid":"123456",

--- a/rackspace/compute/v2/servers/requests.go
+++ b/rackspace/compute/v2/servers/requests.go
@@ -12,12 +12,23 @@ type CreateOpts struct {
 	// Name [required] is the name to assign to the newly launched server.
 	Name string
 
-	// ImageRef [required] is the ID or full URL to the image that contains the server's OS and initial state.
-	// Optional if using the boot-from-volume extension.
+	// ImageRef [optional; required if ImageName is not provided] is the ID or full
+	// URL to the image that contains the server's OS and initial state.
+	// Also optional if using the boot-from-volume extension.
 	ImageRef string
 
-	// FlavorRef [required] is the ID or full URL to the flavor that describes the server's specs.
+	// ImageName [optional; required if ImageRef is not provided] is the name of the
+	// image that contains the server's OS and initial state.
+	// Also optional if using the boot-from-volume extension.
+	ImageName string
+
+	// FlavorRef [optional; required if FlavorName is not provided] is the ID or
+	// full URL to the flavor that describes the server's specs.
 	FlavorRef string
+
+	// FlavorName [optional; required if FlavorRef is not provided] is the name of
+	// the flavor that describes the server's specs.
+	FlavorName string
 
 	// SecurityGroups [optional] lists the names of the security groups to which this server should belong.
 	SecurityGroups []string
@@ -68,7 +79,9 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	base := os.CreateOpts{
 		Name:             opts.Name,
 		ImageRef:         opts.ImageRef,
+		ImageName:        opts.ImageName,
 		FlavorRef:        opts.FlavorRef,
+		FlavorName:       opts.FlavorName,
 		SecurityGroups:   opts.SecurityGroups,
 		UserData:         opts.UserData,
 		AvailabilityZone: opts.AvailabilityZone,

--- a/rackspace/compute/v2/servers/requests_test.go
+++ b/rackspace/compute/v2/servers/requests_test.go
@@ -22,6 +22,8 @@ func TestCreateOpts(t *testing.T) {
 			"name": "createdserver",
 			"imageRef": "image-id",
 			"flavorRef": "flavor-id",
+			"flavorName": "",
+			"imageName": "",
 			"key_name": "mykey",
 			"OS-DCF:diskConfig": "MANUAL"
 		}


### PR DESCRIPTION
This PR lets users create servers by providing image and flavor names (instead of having to provide IDs).