### PR TITLE
Rackspace CLB ExtractNodes call does not propagate errors correctly

### DIFF
--- a/pagination/http.go
+++ b/pagination/http.go
@@ -36,13 +36,19 @@ func PageResultFrom(resp *http.Response) (PageResult, error) {
 		parsedBody = rawBody
 	}
 
+	return PageResultFromParsed(resp, parsedBody), err
+}
+
+// PageResultFromParsed constructs a PageResult from an HTTP response that has already had its
+// body parsed as JSON (and closed).
+func PageResultFromParsed(resp *http.Response, body interface{}) PageResult {
 	return PageResult{
 		Result: gophercloud.Result{
-			Body:   parsedBody,
+			Body:   body,
 			Header: resp.Header,
 		},
 		URL: *resp.Request.URL,
-	}, err
+	}
 }
 
 // Request performs an HTTP request and extracts the http.Response from the result.

--- a/rackspace/lb/v1/nodes/fixtures.go
+++ b/rackspace/lb/v1/nodes/fixtures.go
@@ -107,6 +107,42 @@ func mockCreateResponse(t *testing.T, lbID int) {
 	})
 }
 
+func mockCreateErrResponse(t *testing.T, lbID int) {
+	th.Mux.HandleFunc(_rootURL(lbID), func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		th.TestJSONRequest(t, r, `
+{
+  "nodes": [
+    {
+      "address": "10.2.2.3",
+      "port": 80,
+      "condition": "ENABLED",
+      "type": "PRIMARY"
+    },
+    {
+      "address": "10.2.2.4",
+      "port": 81,
+      "condition": "ENABLED",
+      "type": "SECONDARY"
+    }
+  ]
+}
+    `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(422) // Unprocessable Entity
+
+		fmt.Fprintf(w, `
+{
+  "code": 422,
+  "message": "Load Balancer '%d' has a status of 'PENDING_UPDATE' and is considered immutable."
+}
+  `, lbID)
+	})
+}
+
 func mockBatchDeleteResponse(t *testing.T, lbID int, ids []int) {
 	th.Mux.HandleFunc(_rootURL(lbID), func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")

--- a/rackspace/lb/v1/nodes/requests.go
+++ b/rackspace/lb/v1/nodes/requests.go
@@ -119,10 +119,12 @@ func Create(client *gophercloud.ServiceClient, loadBalancerID int, opts CreateOp
 		return res
 	}
 
-	pr, err := pagination.PageResultFrom(resp)
-	if err != nil {
-		res.Err = err
-		return res
+	pr := pagination.PageResult{
+		Result: gophercloud.Result{
+			Body:   res.Body,
+			Header: resp.Header,
+		},
+		URL: *resp.Request.URL,
 	}
 
 	return CreateResult{pagination.SinglePageBase(pr)}

--- a/rackspace/lb/v1/nodes/requests.go
+++ b/rackspace/lb/v1/nodes/requests.go
@@ -119,14 +119,7 @@ func Create(client *gophercloud.ServiceClient, loadBalancerID int, opts CreateOp
 		return res
 	}
 
-	pr := pagination.PageResult{
-		Result: gophercloud.Result{
-			Body:   res.Body,
-			Header: resp.Header,
-		},
-		URL: *resp.Request.URL,
-	}
-
+	pr := pagination.PageResultFromParsed(resp, res.Body)
 	return CreateResult{pagination.SinglePageBase(pr)}
 }
 

--- a/rackspace/lb/v1/nodes/requests_test.go
+++ b/rackspace/lb/v1/nodes/requests_test.go
@@ -108,6 +108,38 @@ func TestCreate(t *testing.T) {
 	th.CheckDeepEquals(t, expected, actual)
 }
 
+func TestCreateErr(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateErrResponse(t, lbID)
+
+	opts := CreateOpts{
+		CreateOpt{
+			Address:   "10.2.2.3",
+			Port:      80,
+			Condition: ENABLED,
+			Type:      PRIMARY,
+		},
+		CreateOpt{
+			Address:   "10.2.2.4",
+			Port:      81,
+			Condition: ENABLED,
+			Type:      SECONDARY,
+		},
+	}
+
+	page := Create(client.ServiceClient(), lbID, opts)
+
+	actual, err := page.ExtractNodes()
+	if err == nil {
+		t.Fatal("Did not receive expected error from ExtractNodes")
+	}
+	if actual != nil {
+		t.Fatalf("Received non-nil result from failed ExtractNodes: %#v", actual)
+	}
+}
+
 func TestBulkDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/rackspace/lb/v1/nodes/results.go
+++ b/rackspace/lb/v1/nodes/results.go
@@ -126,6 +126,9 @@ type CreateResult struct {
 
 // ExtractNodes extracts a slice of Node structs from a CreateResult.
 func (res CreateResult) ExtractNodes() ([]Node, error) {
+	if res.Err != nil {
+		return nil, res.Err
+	}
 	return commonExtractNodes(res.Body)
 }
 


### PR DESCRIPTION
I hit this playing around with rgbkrk/peekaboo#6. If a `nodes.Create` call fails, the result type's `ExtractNodes` method does not correctly return the error:

```
2015/06/24 13:23:19 Setting 10.209.224.145:2222 to be ENABLED on load balancer 477349
2015/06/24 13:23:19 Creating new node.
POST /v1.0/864477/loadbalancers/477349/nodes HTTP/1.1
Accept: application/json
Content-Type: application/json
User-Agent: gophercloud/1.0.0
X-Auth-Token: ...

{
  "nodes": [
    {
      "address": "10.209.224.145",
      "condition": "ENABLED",
      "port": 2222
    }
  ]
}
HTTP/1.1 422 Unprocessable Entity
Content-Length: 109
Content-Type: application/json
Date: Wed, 24 Jun 2015 13:23:19 GMT
Server: Jetty(8.0.y.z-SNAPSHOT)
Via: 1.1 Rackspace Cloud Load Balancer API v1.24.1 (Repose/2.11.0)
{
  "code": 422,
  "message": "Load Balancer '477349' has a status of 'PENDING_UPDATE' and is considered immutable."
}
2015/06/24 13:23:19 Something went terribly wrong during node creation: []nodes.Node(nil)
```