### PR TITLE
Add all_tenants to nova servers list

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -49,6 +49,9 @@ type ListOpts struct {
 
 	// Integer value for the limit of values to return.
 	Limit int `q:"limit"`
+
+	// Bool to show all tenants
+	AllTenants bool `q:"all_tenants"`
 }
 
 // ToServerListQuery formats a ListOpts into a query string.


### PR DESCRIPTION
"nova list" functionality in gophercloud is missing an optional parameter "all_tenants" which is useful for users with admin role. Compatible (ignored) for non-admins.