### PR TITLE
Object create: ETag bug fix

### DIFF
--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -1,6 +1,7 @@
 package objects
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/sha1"
@@ -9,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rackspace/gophercloud"
-	"github.com/rackspace/gophercloud/openstack/objectstorage/v1/accounts"
-	"github.com/rackspace/gophercloud/pagination"
+	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
+	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/accounts"
+	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the List
@@ -211,15 +212,18 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 		url += query
 	}
 
+	var contentBuffer *bytes.Buffer
+	contentReader := io.TeeReader(content, contentBuffer)
+
 	hash := md5.New()
-	io.Copy(hash, content)
+	io.Copy(hash, contentReader)
 	localChecksum := hash.Sum(nil)
 	fmt.Printf("localChecksum: %s", fmt.Sprintf("%x", localChecksum))
 
 	h["ETag"] = fmt.Sprintf("%x", localChecksum)
 
 	ropts := gophercloud.RequestOpts{
-		RawBody:     content,
+		RawBody:     strings.NewReader(contentBuffer.String()),
 		MoreHeaders: h,
 	}
 

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
-	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/accounts"
-	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack/objectstorage/v1/accounts"
+	"github.com/rackspace/gophercloud/pagination"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the List

--- a/openstack/objectstorage/v1/objects/requests.go
+++ b/openstack/objectstorage/v1/objects/requests.go
@@ -228,9 +228,11 @@ func Create(c *gophercloud.ServiceClient, containerName, objectName string, cont
 	hash := md5.New()
 	io.Copy(hash, content)
 	localChecksum := hash.Sum(nil)
+	fmt.Printf("localChecksum: %s", fmt.Sprintf("%x", localChecksum))
 
 	for i := 1; i <= 3; i++ {
 		resp, err := doUpload()
+		fmt.Printf("ETag: %s", resp.Header.Get("ETag"))
 		if resp.Header.Get("ETag") == fmt.Sprintf("%x", localChecksum) {
 			res.Err = err
 			break


### PR DESCRIPTION
Once the `io.Reader` is read, it can't be re-read. This PR simultaneously creates a hash of the object and writes the content to a buffer. The buffer is then converted to a reader and passed as the request body.