### PR TITLE
Fix time format used for cloud orchestration

### DIFF
--- a/openstack/orchestration/v1/stackevents/fixtures.go
+++ b/openstack/orchestration/v1/stackevents/fixtures.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/rackspace/gophercloud"
 	th "github.com/rackspace/gophercloud/testhelper"
@@ -15,7 +14,7 @@ import (
 var FindExpected = []Event{
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 11, 0, time.UTC),
+		Time:         "2015-02-05T21:33:11",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -38,7 +37,7 @@ var FindExpected = []Event{
 	},
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 27, 0, time.UTC),
+		Time:         "2015-02-05T21:33:27",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -67,7 +66,7 @@ const FindOutput = `
   "events": [
   {
     "resource_name": "hello_world",
-    "event_time": "2015-02-05T21:33:11Z",
+    "event_time": "2015-02-05T21:33:11",
     "links": [
     {
       "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -90,7 +89,7 @@ const FindOutput = `
     },
     {
       "resource_name": "hello_world",
-      "event_time": "2015-02-05T21:33:27Z",
+      "event_time": "2015-02-05T21:33:27",
       "links": [
       {
         "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -132,7 +131,7 @@ func HandleFindSuccessfully(t *testing.T, output string) {
 var ListExpected = []Event{
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 11, 0, time.UTC),
+		Time:         "2015-02-05T21:33:11",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -155,7 +154,7 @@ var ListExpected = []Event{
 	},
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 27, 0, time.UTC),
+		Time:         "2015-02-05T21:33:27",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -184,7 +183,7 @@ const ListOutput = `
   "events": [
   {
     "resource_name": "hello_world",
-    "event_time": "2015-02-05T21:33:11Z",
+    "event_time": "2015-02-05T21:33:11",
     "links": [
     {
       "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -207,7 +206,7 @@ const ListOutput = `
     },
     {
       "resource_name": "hello_world",
-      "event_time": "2015-02-05T21:33:27Z",
+      "event_time": "2015-02-05T21:33:27",
       "links": [
       {
         "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -257,7 +256,7 @@ func HandleListSuccessfully(t *testing.T, output string) {
 var ListResourceEventsExpected = []Event{
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 11, 0, time.UTC),
+		Time:         "2015-02-05T21:33:11",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -280,7 +279,7 @@ var ListResourceEventsExpected = []Event{
 	},
 	Event{
 		ResourceName: "hello_world",
-		Time:         time.Date(2015, 2, 5, 21, 33, 27, 0, time.UTC),
+		Time:         "2015-02-05T21:33:27",
 		Links: []gophercloud.Link{
 			gophercloud.Link{
 				Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -309,7 +308,7 @@ const ListResourceEventsOutput = `
   "events": [
   {
     "resource_name": "hello_world",
-    "event_time": "2015-02-05T21:33:11Z",
+    "event_time": "2015-02-05T21:33:11",
     "links": [
     {
       "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/06feb26f-9298-4a9b-8749-9d770e5d577a",
@@ -332,7 +331,7 @@ const ListResourceEventsOutput = `
     },
     {
       "resource_name": "hello_world",
-      "event_time": "2015-02-05T21:33:27Z",
+      "event_time": "2015-02-05T21:33:27",
       "links": [
       {
         "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -381,7 +380,7 @@ func HandleListResourceEventsSuccessfully(t *testing.T, output string) {
 // GetExpected represents the expected object from a Get request.
 var GetExpected = &Event{
 	ResourceName: "hello_world",
-	Time:         time.Date(2015, 2, 5, 21, 33, 27, 0, time.UTC),
+	Time:         "2015-02-05T21:33:27",
 	Links: []gophercloud.Link{
 		gophercloud.Link{
 			Href: "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",
@@ -408,7 +407,7 @@ const GetOutput = `
 {
   "event":{
     "resource_name": "hello_world",
-    "event_time": "2015-02-05T21:33:27Z",
+    "event_time": "2015-02-05T21:33:27",
     "links": [
     {
       "href": "http://166.78.160.107:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/5f57cff9-93fc-424e-9f78-df0515e7f48b/resources/hello_world/events/93940999-7d40-44ae-8de4-19624e7b8d18",

--- a/openstack/orchestration/v1/stackevents/results.go
+++ b/openstack/orchestration/v1/stackevents/results.go
@@ -10,6 +10,9 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
+// Time format used in cloud orchestration
+const STACK_TIME_FMT = "2006-01-02T15:04:05"
+
 // Event represents a stack event.
 type Event struct {
 	// The name of the resource for which the event occurred.

--- a/openstack/orchestration/v1/stackresources/fixtures.go
+++ b/openstack/orchestration/v1/stackresources/fixtures.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/rackspace/gophercloud"
 	th "github.com/rackspace/gophercloud/testhelper"
@@ -27,7 +26,7 @@ var FindExpected = []Resource{
 		},
 		LogicalID:    "hello_world",
 		StatusReason: "state changed",
-		UpdatedTime:  time.Date(2015, 2, 5, 21, 33, 11, 0, time.UTC),
+		UpdatedTime:  "2015-02-05T21:33:11",
 		RequiredBy:   []interface{}{},
 		Status:       "CREATE_IN_PROGRESS",
 		PhysicalID:   "49181cd6-169a-4130-9455-31185bbfc5bf",
@@ -53,7 +52,7 @@ const FindOutput = `
     ],
     "logical_resource_id": "hello_world",
     "resource_status_reason": "state changed",
-    "updated_time": "2015-02-05T21:33:11Z",
+    "updated_time": "2015-02-05T21:33:11",
     "required_by": [],
     "resource_status": "CREATE_IN_PROGRESS",
     "physical_resource_id": "49181cd6-169a-4130-9455-31185bbfc5bf",
@@ -92,7 +91,7 @@ var ListExpected = []Resource{
 		},
 		LogicalID:    "hello_world",
 		StatusReason: "state changed",
-		UpdatedTime:  time.Date(2015, 2, 5, 21, 33, 11, 0, time.UTC),
+		UpdatedTime:  "2015-02-05T21:33:11",
 		RequiredBy:   []interface{}{},
 		Status:       "CREATE_IN_PROGRESS",
 		PhysicalID:   "49181cd6-169a-4130-9455-31185bbfc5bf",
@@ -117,7 +116,7 @@ const ListOutput = `{
     ],
     "logical_resource_id": "hello_world",
     "resource_status_reason": "state changed",
-    "updated_time": "2015-02-05T21:33:11Z",
+    "updated_time": "2015-02-05T21:33:11",
     "required_by": [],
     "resource_status": "CREATE_IN_PROGRESS",
     "physical_resource_id": "49181cd6-169a-4130-9455-31185bbfc5bf",
@@ -163,7 +162,7 @@ var GetExpected = &Resource{
 	},
 	LogicalID:    "wordpress_instance",
 	StatusReason: "state changed",
-	UpdatedTime:  time.Date(2014, 12, 10, 18, 34, 35, 0, time.UTC),
+	UpdatedTime:  "2014-12-10T18:34:35",
 	RequiredBy:   []interface{}{},
 	Status:       "CREATE_COMPLETE",
 	PhysicalID:   "00e3a2fe-c65d-403c-9483-4db9930dd194",
@@ -188,7 +187,7 @@ const GetOutput = `
     ],
     "logical_resource_id": "wordpress_instance",
     "resource_status": "CREATE_COMPLETE",
-    "updated_time": "2014-12-10T18:34:35Z",
+    "updated_time": "2014-12-10T18:34:35",
     "required_by": [],
     "resource_status_reason": "state changed",
     "physical_resource_id": "00e3a2fe-c65d-403c-9483-4db9930dd194",

--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -10,6 +10,9 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
+// Time format used in cloud orchestration
+const STACK_TIME_FMT = "2006-01-02T15:04:05"
+
 // Resource represents a stack resource.
 type Resource struct {
 	Links        []gophercloud.Link `mapstructure:"links"`

--- a/openstack/orchestration/v1/stacks/fixtures.go
+++ b/openstack/orchestration/v1/stacks/fixtures.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/rackspace/gophercloud"
 	th "github.com/rackspace/gophercloud/testhelper"
@@ -60,7 +59,7 @@ var ListExpected = []ListedStack{
 		},
 		StatusReason: "Stack CREATE completed successfully",
 		Name:         "postman_stack",
-		CreationTime: time.Date(2015, 2, 3, 20, 7, 39, 0, time.UTC),
+		CreationTime: "2015-02-03T20:07:39",
 		Status:       "CREATE_COMPLETE",
 		ID:           "16ef0584-4458-41eb-87c8-0dc8d5f66c87",
 	},
@@ -74,8 +73,8 @@ var ListExpected = []ListedStack{
 		},
 		StatusReason: "Stack successfully updated",
 		Name:         "gophercloud-test-stack-2",
-		CreationTime: time.Date(2014, 12, 11, 17, 39, 16, 0, time.UTC),
-		UpdatedTime:  time.Date(2014, 12, 11, 17, 40, 37, 0, time.UTC),
+		CreationTime:  "2014-12-11T17:39:16",
+		UpdatedTime:  "2014-12-11T17:40:37",
 		Status:       "UPDATE_COMPLETE",
 		ID:           "db6977b2-27aa-4775-9ae7-6213212d4ada",
 	},
@@ -95,7 +94,7 @@ const FullListOutput = `
     ],
     "stack_status_reason": "Stack CREATE completed successfully",
     "stack_name": "postman_stack",
-    "creation_time": "2015-02-03T20:07:39Z",
+    "creation_time": "2015-02-03T20:07:39",
     "updated_time": null,
     "stack_status": "CREATE_COMPLETE",
     "id": "16ef0584-4458-41eb-87c8-0dc8d5f66c87"
@@ -110,8 +109,8 @@ const FullListOutput = `
     ],
     "stack_status_reason": "Stack successfully updated",
     "stack_name": "gophercloud-test-stack-2",
-    "creation_time": "2014-12-11T17:39:16Z",
-    "updated_time": "2014-12-11T17:40:37Z",
+    "creation_time": "2014-12-11T17:39:16",
+    "updated_time": "2014-12-11T17:40:37",
     "stack_status": "UPDATE_COMPLETE",
     "id": "db6977b2-27aa-4775-9ae7-6213212d4ada"
   }
@@ -153,7 +152,7 @@ var GetExpected = &RetrievedStack{
 	StatusReason: "Stack CREATE completed successfully",
 	Name:         "postman_stack",
 	Outputs:      []map[string]interface{}{},
-	CreationTime: time.Date(2015, 2, 3, 20, 7, 39, 0, time.UTC),
+	CreationTime: "2015-02-03T20:07:39",
 	Links: []gophercloud.Link{
 		gophercloud.Link{
 			Href: "http://166.76.160.117:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87",
@@ -181,7 +180,7 @@ const GetOutput = `
     "stack_status_reason": "Stack CREATE completed successfully",
     "stack_name": "postman_stack",
     "outputs": [],
-    "creation_time": "2015-02-03T20:07:39Z",
+    "creation_time": "2015-02-03T20:07:39",
     "links": [
     {
       "href": "http://166.76.160.117:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87",
@@ -250,7 +249,7 @@ var PreviewExpected = &PreviewedStack{
 	},
 	StatusReason: "Stack CREATE completed successfully",
 	Name:         "postman_stack",
-	CreationTime: time.Date(2015, 2, 3, 20, 7, 39, 0, time.UTC),
+	CreationTime: "2015-02-03T20:07:39",
 	Links: []gophercloud.Link{
 		gophercloud.Link{
 			Href: "http://166.76.160.117:8004/v1/98606384f58d4ad0b3db7d0d779549ac/stacks/postman_stack/16ef0584-4458-41eb-87c8-0dc8d5f66c87",

--- a/openstack/orchestration/v1/stacks/results.go
+++ b/openstack/orchestration/v1/stacks/results.go
@@ -11,6 +11,9 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
+// Time format used in cloud orchestration
+const STACK_TIME_FMT = "2006-01-02T15:04:05"
+
 // CreatedStack represents the object extracted from a Create operation.
 type CreatedStack struct {
 	ID    string             `mapstructure:"id"`
@@ -100,7 +103,7 @@ func ExtractStacks(page pagination.Page) ([]ListedStack, error) {
 		thisStack := (rawStacks[i]).(map[string]interface{})
 
 		if t, ok := thisStack["creation_time"].(string); ok && t != "" {
-			creationTime, err := time.Parse(time.RFC3339, t)
+			creationTime, err := time.Parse(STACK_TIME_FMT, t)
 			if err != nil {
 				return res.Stacks, err
 			}
@@ -108,7 +111,7 @@ func ExtractStacks(page pagination.Page) ([]ListedStack, error) {
 		}
 
 		if t, ok := thisStack["updated_time"].(string); ok && t != "" {
-			updatedTime, err := time.Parse(time.RFC3339, t)
+			updatedTime, err := time.Parse(STACK_TIME_FMT, t)
 			if err != nil {
 				return res.Stacks, err
 			}
@@ -170,7 +173,7 @@ func (r GetResult) Extract() (*RetrievedStack, error) {
 	b := r.Body.(map[string]interface{})["stack"].(map[string]interface{})
 
 	if date, ok := b["creation_time"]; ok && date != nil {
-		t, err := time.Parse(time.RFC3339, date.(string))
+		t, err := time.Parse(STACK_TIME_FMT, date.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +181,7 @@ func (r GetResult) Extract() (*RetrievedStack, error) {
 	}
 
 	if date, ok := b["updated_time"]; ok && date != nil {
-		t, err := time.Parse(time.RFC3339, date.(string))
+		t, err := time.Parse(STACK_TIME_FMT, date.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -249,7 +252,7 @@ func (r PreviewResult) Extract() (*PreviewedStack, error) {
 	b := r.Body.(map[string]interface{})["stack"].(map[string]interface{})
 
 	if date, ok := b["creation_time"]; ok && date != nil {
-		t, err := time.Parse(time.RFC3339, date.(string))
+		t, err := time.Parse(STACK_TIME_FMT, date.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +260,7 @@ func (r PreviewResult) Extract() (*PreviewedStack, error) {
 	}
 
 	if date, ok := b["updated_time"]; ok && date != nil {
-		t, err := time.Parse(time.RFC3339, date.(string))
+		t, err := time.Parse(STACK_TIME_FMT, date.(string))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The format used to represent time is slightly different than RFC
standard and the one present in GO time lib.

Fixes https://github.com/rackspace/gophercloud/issues/463