### PR TITLE
Fix Pagination for list StackResources

### DIFF
--- a/openstack/orchestration/v1/stackresources/requests.go
+++ b/openstack/orchestration/v1/stackresources/requests.go
@@ -25,12 +25,6 @@ type ListOptsBuilder interface {
 // ListOpts allows the filtering and sorting of paginated collections through
 // the API. Marker and Limit are used for pagination.
 type ListOpts struct {
-	// The stack resource ID with which to start the listing.
-	Marker string `q:"marker"`
-
-	// Integer value for the limit of values to return.
-	Limit int `q:"limit"`
-
 	// Include resources from nest stacks up to Depth levels of recursion.
 	Depth int `q:"nested_depth"`
 }
@@ -57,9 +51,7 @@ func List(client *gophercloud.ServiceClient, stackName, stackID string, opts Lis
 	}
 
 	createPageFn := func(r pagination.PageResult) pagination.Page {
-		p := ResourcePage{pagination.MarkerPageBase{PageResult: r}}
-		p.MarkerPageBase.Owner = p
-		return p
+		return ResourcePage{pagination.SinglePageBase(r)}
 	}
 
 	return pagination.NewPager(client, url, createPageFn)

--- a/openstack/orchestration/v1/stackresources/results.go
+++ b/openstack/orchestration/v1/stackresources/results.go
@@ -63,7 +63,7 @@ func (r FindResult) Extract() ([]Resource, error) {
 // As OpenStack extensions may freely alter the response bodies of structures returned to the client, you may only safely access the
 // data provided through the ExtractResources call.
 type ResourcePage struct {
-	pagination.MarkerPageBase
+	pagination.SinglePageBase
 }
 
 // IsEmpty returns true if a page contains no Server results.


### PR DESCRIPTION
The api does not support marker based pagination and this breaks
the clients which loop infinitely over list resource calls.