### PR TITLE
[rfr] Keystone Identity /v3/role_assignments

### DIFF
--- a/openstack/identity/v3/roles/doc.go
+++ b/openstack/identity/v3/roles/doc.go
@@ -1,0 +1,3 @@
+// Package roles provides information and interaction with the roles API
+// resource for the OpenStack Identity service.
+package roles

--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -1,0 +1,31 @@
+package roles
+
+import (
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+// RoleAssignmentsOpts allows you to query the RoleAssignments method.
+type RoleAssignmentsOpts struct {
+	GroupId        string `q:"group.id"`
+	RoleId         string `q:"role.id"`
+	ScopeDomainId  string `q:"scope.domain.id"`
+	ScopeProjectId string `q:"scope.project.id"`
+	UserId         string `q:"user.id"`
+	Effective      bool   `q:"effective"`
+}
+
+// RoleAssignments enumerates the roles assigned to a specified resource.
+func RoleAssignments(client *gophercloud.ServiceClient, opts RoleAssignmentsOpts) pagination.Pager {
+	u := roleAssignmentsURL(client)
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u += q.String()
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return RoleAssignmentsPage{pagination.LinkedPageBase{PageResult: r}}
+	}
+
+	return pagination.NewPager(client, u, createPage)
+}

--- a/openstack/identity/v3/roles/requests_test.go
+++ b/openstack/identity/v3/roles/requests_test.go
@@ -1,0 +1,104 @@
+package roles
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/rackspace/gophercloud/pagination"
+	"github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func TestListSinglePage(t *testing.T) {
+	testhelper.SetupHTTP()
+	defer testhelper.TeardownHTTP()
+
+	testhelper.Mux.HandleFunc("/role_assignments", func(w http.ResponseWriter, r *http.Request) {
+		testhelper.TestMethod(t, r, "GET")
+		testhelper.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, `
+			{
+                "role_assignments": [
+                    {
+                        "links": {
+                            "assignment": "http://identity:35357/v3/domains/161718/users/313233/roles/123456"
+                        },
+                        "role": {
+                            "id": "123456"
+                        },
+                        "scope": {
+                            "domain": {
+                                "id": "161718"
+                            }
+                        },
+                        "user": {
+                            "id": "313233"
+                        }
+                    },
+                    {
+                        "links": {
+                            "assignment": "http://identity:35357/v3/projects/456789/groups/101112/roles/123456",
+                            "membership": "http://identity:35357/v3/groups/101112/users/313233"
+                        },
+                        "role": {
+                            "id": "123456"
+                        },
+                        "scope": {
+                            "project": {
+                                "id": "456789"
+                            }
+                        },
+                        "user": {
+                            "id": "313233"
+                        }
+                    }
+                ],
+                "links": {
+                    "self": "http://identity:35357/v3/role_assignments?effective",
+                    "previous": null,
+                    "next": null
+                }
+            }
+		`)
+	})
+
+	count := 0
+	err := RoleAssignments(client.ServiceClient(), RoleAssignmentsOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := ExtractRoleAssignments(page)
+		if err != nil {
+			return false, err
+		}
+
+		expected := []RoleAssignment{
+			RoleAssignment{
+				Role:  &Role{ID: "123456"},
+				Scope: &Scope{Domain: &Domain{ID: "161718"}},
+				User:  &User{ID: "313233"},
+				Group: nil,
+			},
+			RoleAssignment{
+				Role:  &Role{ID: "123456"},
+				Scope: &Scope{Project: &Project{ID: "456789"}},
+				User:  &User{ID: "313233"},
+				Group: nil,
+			},
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %#v, got %#v", expected, actual)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("Unexpected error while paging: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}

--- a/openstack/identity/v3/roles/requests_test.go
+++ b/openstack/identity/v3/roles/requests_test.go
@@ -67,7 +67,7 @@ func TestListSinglePage(t *testing.T) {
 	})
 
 	count := 0
-	err := RoleAssignments(client.ServiceClient(), RoleAssignmentsOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+	err := ListAssignments(client.ServiceClient(), ListAssignmentsOpts{}).EachPage(func(page pagination.Page) (bool, error) {
 		count++
 		actual, err := ExtractRoleAssignments(page)
 		if err != nil {
@@ -76,16 +76,16 @@ func TestListSinglePage(t *testing.T) {
 
 		expected := []RoleAssignment{
 			RoleAssignment{
-				Role:  &Role{ID: "123456"},
-				Scope: &Scope{Domain: &Domain{ID: "161718"}},
-				User:  &User{ID: "313233"},
-				Group: nil,
+				Role:  Role{ID: "123456"},
+				Scope: Scope{Domain: Domain{ID: "161718"}},
+				User:  User{ID: "313233"},
+				Group: Group{},
 			},
 			RoleAssignment{
-				Role:  &Role{ID: "123456"},
-				Scope: &Scope{Project: &Project{ID: "456789"}},
-				User:  &User{ID: "313233"},
-				Group: nil,
+				Role:  Role{ID: "123456"},
+				Scope: Scope{Project: Project{ID: "456789"}},
+				User:  User{ID: "313233"},
+				Group: Group{},
 			},
 		}
 

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -8,10 +8,10 @@ import (
 
 // RoleAssignment is the result of a role assignments query.
 type RoleAssignment struct {
-	Role  *Role  `json:"role,omitempty"`
-	Scope *Scope `json:"scope,omitempty"`
-	User  *User  `json:"user,omitempty"`
-	Group *Group `json:"group,omitempty"`
+	Role  Role  `json:"role,omitempty"`
+	Scope Scope `json:"scope,omitempty"`
+	User  User  `json:"user,omitempty"`
+	Group Group `json:"group,omitempty"`
 }
 
 type Role struct {
@@ -19,8 +19,8 @@ type Role struct {
 }
 
 type Scope struct {
-	Domain  *Domain  `json:"domain,omitempty"`
-	Project *Project `json:"domain,omitempty"`
+	Domain  Domain  `json:"domain,omitempty"`
+	Project Project `json:"domain,omitempty"`
 }
 
 type Domain struct {
@@ -51,6 +51,23 @@ func (p RoleAssignmentsPage) IsEmpty() (bool, error) {
 		return true, err
 	}
 	return len(roleAssignments) == 0, nil
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the next page of results.
+func (page RoleAssignmentsPage) NextPageURL() (string, error) {
+	type resp struct {
+		Links struct {
+			Next string `mapstructure:"next"`
+		} `mapstructure:"links"`
+	}
+
+	var r resp
+	err := mapstructure.Decode(page.Body, &r)
+	if err != nil {
+		return "", err
+	}
+
+	return r.Links.Next, nil
 }
 
 // ExtractRoleAssignments extracts a slice of RoleAssignments from a Collection acquired from List.

--- a/openstack/identity/v3/roles/results.go
+++ b/openstack/identity/v3/roles/results.go
@@ -1,0 +1,64 @@
+package roles
+
+import (
+	"github.com/rackspace/gophercloud/pagination"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// RoleAssignment is the result of a role assignments query.
+type RoleAssignment struct {
+	Role  *Role  `json:"role,omitempty"`
+	Scope *Scope `json:"scope,omitempty"`
+	User  *User  `json:"user,omitempty"`
+	Group *Group `json:"group,omitempty"`
+}
+
+type Role struct {
+	ID string `json:"id,omitempty"`
+}
+
+type Scope struct {
+	Domain  *Domain  `json:"domain,omitempty"`
+	Project *Project `json:"domain,omitempty"`
+}
+
+type Domain struct {
+	ID string `json:"id,omitempty"`
+}
+
+type Project struct {
+	ID string `json:"id,omitempty"`
+}
+
+type User struct {
+	ID string `json:"id,omitempty"`
+}
+
+type Group struct {
+	ID string `json:"id,omitempty"`
+}
+
+// RoleAssignmentsPage is a single page of RoleAssignments results.
+type RoleAssignmentsPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if the page contains no results.
+func (p RoleAssignmentsPage) IsEmpty() (bool, error) {
+	roleAssignments, err := ExtractRoleAssignments(p)
+	if err != nil {
+		return true, err
+	}
+	return len(roleAssignments) == 0, nil
+}
+
+// ExtractRoleAssignments extracts a slice of RoleAssignments from a Collection acquired from List.
+func ExtractRoleAssignments(page pagination.Page) ([]RoleAssignment, error) {
+	var response struct {
+		RoleAssignments []RoleAssignment `mapstructure:"role_assignments"`
+	}
+
+	err := mapstructure.Decode(page.(RoleAssignmentsPage).Body, &response)
+	return response.RoleAssignments, err
+}

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -1,0 +1,7 @@
+package roles
+
+import "github.com/rackspace/gophercloud"
+
+func roleAssignmentsURL(client *gophercloud.ServiceClient) string {
+	return client.ServiceURL("role_assignments")
+}

--- a/openstack/identity/v3/roles/urls.go
+++ b/openstack/identity/v3/roles/urls.go
@@ -2,6 +2,6 @@ package roles
 
 import "github.com/rackspace/gophercloud"
 
-func roleAssignmentsURL(client *gophercloud.ServiceClient) string {
+func listAssignmentsURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("role_assignments")
 }

--- a/openstack/identity/v3/roles/urls_test.go
+++ b/openstack/identity/v3/roles/urls_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/rackspace/gophercloud"
 )
 
-func TestRoleAssignmentsURL(t *testing.T) {
+func TestListAssignmentsURL(t *testing.T) {
 	client := gophercloud.ServiceClient{Endpoint: "http://localhost:5000/v3/"}
-	url := roleAssignmentsURL(&client)
+	url := listAssignmentsURL(&client)
 	if url != "http://localhost:5000/v3/role_assignments" {
 		t.Errorf("Unexpected list URL generated: [%s]", url)
 	}

--- a/openstack/identity/v3/roles/urls_test.go
+++ b/openstack/identity/v3/roles/urls_test.go
@@ -1,0 +1,15 @@
+package roles
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud"
+)
+
+func TestRoleAssignmentsURL(t *testing.T) {
+	client := gophercloud.ServiceClient{Endpoint: "http://localhost:5000/v3/"}
+	url := roleAssignmentsURL(&client)
+	if url != "http://localhost:5000/v3/role_assignments" {
+		t.Errorf("Unexpected list URL generated: [%s]", url)
+	}
+}


### PR DESCRIPTION
This implements the /v3/role_assignments part of roles API, which complements existing v2 functions already implemented in gophercloud. Querying role assignments is, however, only available in v3 and this patch makes it usable.