### PR TITLE
[RFR] OpenStack Compute Start/Stop Server

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -852,3 +852,25 @@ func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) 
 		return "", fmt.Errorf("Found %d servers matching %s", serverCount, name)
 	}
 }
+
+// Start allows you to start a server that was previously stopped.
+func Start(client *gophercloud.ServiceClient, id string) ActionResult {
+	var res ActionResult
+
+	reqBody := map[string]interface{}{"os-start": nil}
+	_, res.Err = client.Post(actionURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return res
+}
+
+// Stop allows you to shut off a server in ACTIVE or ERROR state.
+func Stop(client *gophercloud.ServiceClient, id string) ActionResult {
+	var res ActionResult
+
+	reqBody := map[string]interface{}{"os-stop": nil}
+	_, res.Err = client.Post(actionURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return res
+}

--- a/openstack/compute/v2/servers/requests_test.go
+++ b/openstack/compute/v2/servers/requests_test.go
@@ -371,3 +371,35 @@ func TestMarshalPersonality(t *testing.T) {
 		t.Fatal("file contents incorrect")
 	}
 }
+
+func TestStart(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{ "os-start": null }`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	res := Start(client.ServiceClient(), "1234asdf")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestStop(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/servers/1234asdf/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{ "os-stop": null }`)
+
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	res := Stop(client.ServiceClient(), "1234asdf")
+	th.AssertNoErr(t, res.Err)
+}


### PR DESCRIPTION
Added the ability to start/stop OpenStack Nova instances (V2 API Extensions).

Unit tests included.