### PR TITLE
[rfr] Allow setting tenantID when creating security-groups

### DIFF
--- a/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/openstack/networking/v2/extensions/security/groups/requests.go
@@ -45,6 +45,9 @@ type CreateOpts struct {
 	// Required. Human-readable name for the VIP. Does not have to be unique.
 	Name string
 
+	// Required for admins. Indicates the owner of the VIP.
+	TenantID string
+
 	// Optional. Describes the security group.
 	Description string
 }
@@ -62,6 +65,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 
 	type secgroup struct {
 		Name        string `json:"name"`
+		TenantID    string `json:"tenant_id,omitempty"`
 		Description string `json:"description,omitempty"`
 	}
 
@@ -71,6 +75,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 
 	reqBody := request{SecGroup: secgroup{
 		Name:        opts.Name,
+		TenantID:    opts.TenantID,
 		Description: opts.Description,
 	}}
 

--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -99,6 +99,9 @@ type CreateOpts struct {
 	// attribute matches the specified IP prefix as the source IP address of the
 	// IP packet.
 	RemoteIPPrefix string
+
+	// Required for admins. Indicates the owner of the VIP.
+	TenantID string
 }
 
 // Create is an operation which provisions a new security group with default
@@ -133,6 +136,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Protocol       string `json:"protocol,omitempty"`
 		RemoteGroupID  string `json:"remote_group_id,omitempty"`
 		RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
+		TenantID       string `json:"tenant_id,omitempty"`
 	}
 
 	type request struct {
@@ -148,6 +152,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Protocol:       opts.Protocol,
 		RemoteGroupID:  opts.RemoteGroupID,
 		RemoteIPPrefix: opts.RemoteIPPrefix,
+		TenantID:       opts.TenantID,
 	}}
 
 	_, res.Err = c.Post(rootURL(c), reqBody, &res.Body, nil)


### PR DESCRIPTION
Allow setting tenantID when creating security-groups