### PR TITLE
[rfr] Reorganized volumes and volumeattach to move fixtures to subpackage

### DIFF
--- a/openstack/blockstorage/v1/volumes/requests_test.go
+++ b/openstack/blockstorage/v1/volumes/requests_test.go
@@ -3,6 +3,7 @@ package volumes
 import (
 	"testing"
 
+	fixtures "github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes/testing"
 	"github.com/rackspace/gophercloud/pagination"
 	th "github.com/rackspace/gophercloud/testhelper"
 	"github.com/rackspace/gophercloud/testhelper/client"
@@ -12,7 +13,7 @@ func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockListResponse(t)
+	fixtures.MockListResponse(t)
 
 	count := 0
 
@@ -49,7 +50,7 @@ func TestListAll(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockListResponse(t)
+	fixtures.MockListResponse(t)
 
 	allPages, err := List(client.ServiceClient(), &ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
@@ -75,7 +76,7 @@ func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockGetResponse(t)
+	fixtures.MockGetResponse(t)
 
 	v, err := Get(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22").Extract()
 	th.AssertNoErr(t, err)
@@ -89,7 +90,7 @@ func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockCreateResponse(t)
+	fixtures.MockCreateResponse(t)
 
 	options := &CreateOpts{Size: 75}
 	n, err := Create(client.ServiceClient(), options).Extract()
@@ -103,7 +104,7 @@ func TestDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockDeleteResponse(t)
+	fixtures.MockDeleteResponse(t)
 
 	res := Delete(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22")
 	th.AssertNoErr(t, res.Err)
@@ -113,7 +114,7 @@ func TestUpdate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
-	MockUpdateResponse(t)
+	fixtures.MockUpdateResponse(t)
 
 	options := UpdateOpts{Name: "vol-002"}
 	v, err := Update(client.ServiceClient(), "d32019d3-bc6e-4319-9c1d-6722fc136a22", options).Extract()

--- a/openstack/blockstorage/v1/volumes/testing/doc.go
+++ b/openstack/blockstorage/v1/volumes/testing/doc.go
@@ -1,0 +1,7 @@
+/*
+This is package created is to hold fixtures (which imports testing),
+so that importing volumes package does not inadvertently import testing into production code
+More information here:
+https://github.com/rackspace/gophercloud/issues/473
+*/
+package testing

--- a/openstack/blockstorage/v1/volumes/testing/fixtures.go
+++ b/openstack/blockstorage/v1/volumes/testing/fixtures.go
@@ -1,4 +1,4 @@
-package volumes
+package testing
 
 import (
 	"fmt"

--- a/openstack/compute/v2/extensions/volumeattach/requests_test.go
+++ b/openstack/compute/v2/extensions/volumeattach/requests_test.go
@@ -3,15 +3,44 @@ package volumeattach
 import (
 	"testing"
 
+	fixtures "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach/testing"
 	"github.com/rackspace/gophercloud/pagination"
 	th "github.com/rackspace/gophercloud/testhelper"
 	"github.com/rackspace/gophercloud/testhelper/client"
 )
 
+// FirstVolumeAttachment is the first result in ListOutput.
+var FirstVolumeAttachment = VolumeAttachment{
+	Device:   "/dev/vdd",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+}
+
+// SecondVolumeAttachment is the first result in ListOutput.
+var SecondVolumeAttachment = VolumeAttachment{
+	Device:   "/dev/vdc",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+}
+
+// ExpectedVolumeAttachmentSlide is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedVolumeAttachmentSlice = []VolumeAttachment{FirstVolumeAttachment, SecondVolumeAttachment}
+
+//CreatedVolumeAttachment is the parsed result from CreatedOutput.
+var CreatedVolumeAttachment = VolumeAttachment{
+	Device:   "/dev/vdc",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+}
+
 func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleListSuccessfully(t)
+	fixtures.HandleListSuccessfully(t)
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
 	count := 0
@@ -30,7 +59,7 @@ func TestList(t *testing.T) {
 func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleCreateSuccessfully(t)
+	fixtures.HandleCreateSuccessfully(t)
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
 	actual, err := Create(client.ServiceClient(), serverId, CreateOpts{
@@ -44,7 +73,7 @@ func TestCreate(t *testing.T) {
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleGetSuccessfully(t)
+	fixtures.HandleGetSuccessfully(t)
 	aId := "a26887c6-c47b-4654-abb5-dfadf7d3f804"
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
@@ -56,7 +85,7 @@ func TestGet(t *testing.T) {
 func TestDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	HandleDeleteSuccessfully(t)
+	fixtures.HandleDeleteSuccessfully(t)
 	aId := "a26887c6-c47b-4654-abb5-dfadf7d3f804"
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 

--- a/openstack/compute/v2/extensions/volumeattach/testing/doc.go
+++ b/openstack/compute/v2/extensions/volumeattach/testing/doc.go
@@ -1,0 +1,7 @@
+/*
+This is package created is to hold fixtures (which imports testing),
+so that importing volumeattach package does not inadvertently import testing into production code
+More information here:
+https://github.com/rackspace/gophercloud/issues/473
+*/
+package testing

--- a/openstack/compute/v2/extensions/volumeattach/testing/fixtures.go
+++ b/openstack/compute/v2/extensions/volumeattach/testing/fixtures.go
@@ -1,6 +1,6 @@
 // +build fixtures
 
-package volumeattach
+package testing
 
 import (
 	"fmt"
@@ -54,34 +54,6 @@ const CreateOutput = `
   }
 }
 `
-
-// FirstVolumeAttachment is the first result in ListOutput.
-var FirstVolumeAttachment = VolumeAttachment{
-	Device:   "/dev/vdd",
-	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f803",
-	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
-	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f803",
-}
-
-// SecondVolumeAttachment is the first result in ListOutput.
-var SecondVolumeAttachment = VolumeAttachment{
-	Device:   "/dev/vdc",
-	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
-	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-}
-
-// ExpectedVolumeAttachmentSlide is the slice of results that should be parsed
-// from ListOutput, in the expected order.
-var ExpectedVolumeAttachmentSlice = []VolumeAttachment{FirstVolumeAttachment, SecondVolumeAttachment}
-
-// CreatedVolumeAttachment is the parsed result from CreatedOutput.
-var CreatedVolumeAttachment = VolumeAttachment{
-	Device:   "/dev/vdc",
-	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
-	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
-}
 
 // HandleListSuccessfully configures the test server to respond to a List request.
 func HandleListSuccessfully(t *testing.T) {

--- a/rackspace/blockstorage/v1/volumes/delegate_test.go
+++ b/rackspace/blockstorage/v1/volumes/delegate_test.go
@@ -3,7 +3,8 @@ package volumes
 import (
 	"testing"
 
-	os "github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	os "github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes/testing"
 	"github.com/rackspace/gophercloud/pagination"
 	th "github.com/rackspace/gophercloud/testhelper"
 	fake "github.com/rackspace/gophercloud/testhelper/client"
@@ -64,7 +65,7 @@ func TestCreate(t *testing.T) {
 
 	os.MockCreateResponse(t)
 
-	n, err := Create(fake.ServiceClient(), CreateOpts{os.CreateOpts{Size: 75}}).Extract()
+	n, err := Create(fake.ServiceClient(), CreateOpts{volumes.CreateOpts{Size: 75}}).Extract()
 	th.AssertNoErr(t, err)
 
 	th.AssertEquals(t, n.Size, 4)
@@ -72,12 +73,12 @@ func TestCreate(t *testing.T) {
 }
 
 func TestSizeRange(t *testing.T) {
-	_, err := Create(fake.ServiceClient(), CreateOpts{os.CreateOpts{Size: 1}}).Extract()
+	_, err := Create(fake.ServiceClient(), CreateOpts{volumes.CreateOpts{Size: 1}}).Extract()
 	if err == nil {
 		t.Fatalf("Expected error, got none")
 	}
 
-	_, err = Create(fake.ServiceClient(), CreateOpts{os.CreateOpts{Size: 2000}}).Extract()
+	_, err = Create(fake.ServiceClient(), CreateOpts{volumes.CreateOpts{Size: 2000}}).Extract()
 	if err == nil {
 		t.Fatalf("Expected error, got none")
 	}

--- a/rackspace/compute/v2/volumeattach/delegate_test.go
+++ b/rackspace/compute/v2/volumeattach/delegate_test.go
@@ -3,24 +3,53 @@ package volumeattach
 import (
 	"testing"
 
-	os "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach"
+	fixtures "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/volumeattach/testing"
 	"github.com/rackspace/gophercloud/pagination"
 	th "github.com/rackspace/gophercloud/testhelper"
 	"github.com/rackspace/gophercloud/testhelper/client"
 )
 
+// FirstVolumeAttachment is the first result in ListOutput.
+var FirstVolumeAttachment = volumeattach.VolumeAttachment{
+	Device:   "/dev/vdd",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f803",
+}
+
+// SecondVolumeAttachment is the first result in ListOutput.
+var SecondVolumeAttachment = volumeattach.VolumeAttachment{
+	Device:   "/dev/vdc",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+}
+
+// ExpectedVolumeAttachmentSlide is the slice of results that should be parsed
+// from ListOutput, in the expected order.
+var ExpectedVolumeAttachmentSlice = []volumeattach.VolumeAttachment{FirstVolumeAttachment, SecondVolumeAttachment}
+
+//CreatedVolumeAttachment is the parsed result from CreatedOutput.
+var CreatedVolumeAttachment = volumeattach.VolumeAttachment{
+	Device:   "/dev/vdc",
+	ID:       "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+	ServerID: "4d8c3732-a248-40ed-bebc-539a6ffd25c0",
+	VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
+}
+
 func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	os.HandleListSuccessfully(t)
+	fixtures.HandleListSuccessfully(t)
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
 	count := 0
 	err := List(client.ServiceClient(), serverId).EachPage(func(page pagination.Page) (bool, error) {
 		count++
-		actual, err := os.ExtractVolumeAttachments(page)
+		actual, err := volumeattach.ExtractVolumeAttachments(page)
 		th.AssertNoErr(t, err)
-		th.CheckDeepEquals(t, os.ExpectedVolumeAttachmentSlice, actual)
+		th.CheckDeepEquals(t, ExpectedVolumeAttachmentSlice, actual)
 
 		return true, nil
 	})
@@ -31,33 +60,33 @@ func TestList(t *testing.T) {
 func TestCreate(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	os.HandleCreateSuccessfully(t)
+	fixtures.HandleCreateSuccessfully(t)
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
-	actual, err := Create(client.ServiceClient(), serverId, os.CreateOpts{
+	actual, err := Create(client.ServiceClient(), serverId, volumeattach.CreateOpts{
 		Device:   "/dev/vdc",
 		VolumeID: "a26887c6-c47b-4654-abb5-dfadf7d3f804",
 	}).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &os.CreatedVolumeAttachment, actual)
+	th.CheckDeepEquals(t, &CreatedVolumeAttachment, actual)
 }
 
 func TestGet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	os.HandleGetSuccessfully(t)
+	fixtures.HandleGetSuccessfully(t)
 	aId := "a26887c6-c47b-4654-abb5-dfadf7d3f804"
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 
 	actual, err := Get(client.ServiceClient(), serverId, aId).Extract()
 	th.AssertNoErr(t, err)
-	th.CheckDeepEquals(t, &os.SecondVolumeAttachment, actual)
+	th.CheckDeepEquals(t, &SecondVolumeAttachment, actual)
 }
 
 func TestDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
-	os.HandleDeleteSuccessfully(t)
+	fixtures.HandleDeleteSuccessfully(t)
 	aId := "a26887c6-c47b-4654-abb5-dfadf7d3f804"
 	serverId := "4d8c3732-a248-40ed-bebc-539a6ffd25c0"
 


### PR DESCRIPTION
This PR is to fix #473. It is basically a re-org of volumes and volumeattach packages to move fixtures.go into its own subpackage. Updated dependencies accordingly.[RFR]