### PR TITLE
[rfr]Allow DNSNameservers and HostRoutes to be removed

### DIFF
--- a/openstack/networking/v2/subnets/requests.go
+++ b/openstack/networking/v2/subnets/requests.go
@@ -202,10 +202,10 @@ func (opts UpdateOpts) ToSubnetUpdateMap() (map[string]interface{}, error) {
 	if opts.GatewayIP != "" {
 		s["gateway_ip"] = opts.GatewayIP
 	}
-	if len(opts.DNSNameservers) != 0 {
+	if opts.DNSNameservers != nil {
 		s["dns_nameservers"] = opts.DNSNameservers
 	}
-	if len(opts.HostRoutes) != 0 {
+	if opts.HostRoutes != nil {
 		s["host_routes"] = opts.HostRoutes
 	}
 


### PR DESCRIPTION
Check against nil instead of len == 0 when updating DNSNameservers and
HostRoutes. This allows the removal of already configured properties.