### PR TITLE
[rfr]Make client return error on JSON decoding error

### DIFF
--- a/openstack/compute/v2/extensions/secgroups/fixtures.go
+++ b/openstack/compute/v2/extensions/secgroups/fixtures.go
@@ -242,6 +242,7 @@ func mockAddServerToGroupResponse(t *testing.T, serverID string) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 }
 
@@ -261,5 +262,6 @@ func mockRemoveServerFromGroupResponse(t *testing.T, serverID string) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 }

--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -754,9 +754,7 @@ func Metadatum(client *gophercloud.ServiceClient, id, key string) GetMetadatumRe
 // DeleteMetadatum will delete the key-value pair with the given key for the given server ID.
 func DeleteMetadatum(client *gophercloud.ServiceClient, id, key string) DeleteMetadatumResult {
 	var res DeleteMetadatumResult
-	_, res.Err = client.Delete(metadatumURL(client, id, key), &gophercloud.RequestOpts{
-		JSONResponse: &res.Body,
-	})
+	_, res.Err = client.Delete(metadatumURL(client, id, key), nil)
 	return res
 }
 

--- a/openstack/networking/v2/extensions/fwaas/firewalls/requests_test.go
+++ b/openstack/networking/v2/extensions/fwaas/firewalls/requests_test.go
@@ -212,9 +212,9 @@ func TestUpdate(t *testing.T) {
         "name": "fw",
         "admin_state_up": false,
         "tenant_id": "b4eedccc6fb74fa8a7ad6b08382b852b",
-        "firewall_policy_id": "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c"
+        "firewall_policy_id": "19ab8c87-4a32-4e6a-a74e-b77fffb89a0c",
         "id": "ea5b5315-64f6-4ea3-8e58-981cc37c6576",
-        "description": "OpenStack firewall",
+        "description": "OpenStack firewall"
     }
 }
     `)

--- a/openstack/networking/v2/extensions/lbaas/pools/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests_test.go
@@ -296,6 +296,7 @@ func TestAssociateHealthMonitor(t *testing.T) {
 
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	_, err := AssociateMonitor(fake.ServiceClient(), "332abe93-f488-41ba-870b-2ac66be7f853", "b624decf-d5d3-4c66-9a3d-f047e7786181").Extract()

--- a/openstack/networking/v2/networks/requests_test.go
+++ b/openstack/networking/v2/networks/requests_test.go
@@ -204,6 +204,7 @@ func TestCreateWithOptionalFields(t *testing.T) {
 		`)
 
 		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{}`)
 	})
 
 	iTrue := true

--- a/provider_client.go
+++ b/provider_client.go
@@ -227,7 +227,9 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 	// Parse the response body as JSON, if requested to do so.
 	if options.JSONResponse != nil {
 		defer resp.Body.Close()
-		json.NewDecoder(resp.Body).Decode(options.JSONResponse)
+		if err := json.NewDecoder(resp.Body).Decode(options.JSONResponse); err != nil {
+			return nil, err
+		}
 	}
 
 	return resp, nil

--- a/rackspace/lb/v1/sessions/fixtures.go
+++ b/rackspace/lb/v1/sessions/fixtures.go
@@ -46,6 +46,7 @@ func mockEnableResponse(t *testing.T, lbID int) {
     `)
 
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 }
 

--- a/rackspace/lb/v1/ssl/fixtures.go
+++ b/rackspace/lb/v1/ssl/fixtures.go
@@ -63,6 +63,7 @@ func mockUpdateResponse(t *testing.T, lbID int) {
     `)
 
 		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{}`)
 	})
 }
 

--- a/rackspace/lb/v1/throttle/fixtures.go
+++ b/rackspace/lb/v1/throttle/fixtures.go
@@ -49,6 +49,7 @@ func mockCreateResponse(t *testing.T, lbID int) {
     `)
 
 		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{}`)
 	})
 }
 

--- a/rackspace/networking/v2/networks/delegate_test.go
+++ b/rackspace/networking/v2/networks/delegate_test.go
@@ -203,8 +203,17 @@ func TestCreateWithOptionalFields(t *testing.T) {
 	}
 }
 		`)
-
 		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `
+{
+	"network": {
+			"name": "sample_network",
+			"admin_state_up": true,
+			"shared": true,
+			"tenant_id": "12345"
+	}
+}
+		`)
 	})
 
 	iTrue := true


### PR DESCRIPTION
If the response is not valid JSON, the request simply returns an
empty body. If the user is expecting the result to be JSON and its
not, we should signal that an error has occured.