### PR TITLE
Updating godocs descriptions for SecGroupRule

### DIFF
--- a/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/openstack/networking/v2/extensions/security/rules/requests.go
@@ -104,8 +104,8 @@ type CreateOpts struct {
 	TenantID string
 }
 
-// Create is an operation which provisions a new security group with default
-// security group rules for the IPv4 and IPv6 ether types.
+// Create is an operation which adds a new security group rule and associates it
+// with an existing security group (whose ID is specified in CreateOpts).
 func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	var res CreateResult
 
@@ -159,14 +159,14 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	return res
 }
 
-// Get retrieves a particular security group based on its unique ID.
+// Get retrieves a particular security group rule based on its unique ID.
 func Get(c *gophercloud.ServiceClient, id string) GetResult {
 	var res GetResult
 	_, res.Err = c.Get(resourceURL(c, id), &res.Body, nil)
 	return res
 }
 
-// Delete will permanently delete a particular security group based on its unique ID.
+// Delete will permanently delete a particular security group rule based on its unique ID.
 func Delete(c *gophercloud.ServiceClient, id string) DeleteResult {
 	var res DeleteResult
 	_, res.Err = c.Delete(resourceURL(c, id), nil)


### PR DESCRIPTION
Documentation update

I noticed that some of the godoc method descriptions in the networking/v2/extensions/security/rules package (eg [Create]( https://godoc.org/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/rules#Create)) were  referring to Security Groups instead of Security Group Rules. I'm just updating the function descriptions in those cases.