### PR TITLE
Adding 200 response code for POST request

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -240,7 +240,7 @@ func defaultOkCodes(method string) []int {
 	case method == "GET":
 		return []int{200}
 	case method == "POST":
-		return []int{201, 202}
+		return []int{200, 201, 202}
 	case method == "PUT":
 		return []int{201, 202}
 	case method == "DELETE":


### PR DESCRIPTION
*What*:
Added 200 as ok response code for POST requests.

*Why*:
There is one Rackspace-metrics API (http://docs.rackspace.com/cmet/api/v1.0/cmet-devguide/content/POST_sendMetricsList_views_Query_Operations.html) that responds with 200 code against POST request.

*Is it Okay?*:
Yes, It's OK to send 200 against POST requests.
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html