### PR TITLE
add validate user's token method for v2 and bug fix for reauth

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -167,6 +167,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 
 	if options.AllowReauth {
 		client.ReauthFunc = func() error {
+			client.TokenID = ""
 			return AuthenticateV3(client, options)
 		}
 	}

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -91,12 +91,12 @@ func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) CreateRe
 
 // Validates and retrieves information for user's token.
 func Get(client *gophercloud.ServiceClient, token string) GetResult {
-    var result GetResult
-    _, result.Err = client.Get(CreateGetURL(client, token), &result.Body, &gophercloud.RequestOpts{
-        OkCodes: []int{200, 203},
-    })
-    if result.Err != nil {
-        return result
-    }
-    return result
+	var result GetResult
+	_, result.Err = client.Get(GetURL(client, token), &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 203},
+	})
+	if result.Err != nil {
+		return result
+	}
+	return result
 }

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -88,3 +88,15 @@ func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) CreateRe
 	})
 	return result
 }
+
+// Validates and retrieves information for user's token.
+func Get(client *gophercloud.ServiceClient, token string) GetResult {
+    var result GetResult
+    _, result.Err = client.Get(CreateGetURL(client, token), &result.Body, &gophercloud.RequestOpts{
+        OkCodes: []int{200, 203},
+    })
+    if result.Err != nil {
+        return result
+    }
+    return result
+}

--- a/openstack/identity/v2/tokens/results.go
+++ b/openstack/identity/v2/tokens/results.go
@@ -74,6 +74,11 @@ type CreateResult struct {
 	gophercloud.Result
 }
 
+// GetResult is the deferred response from a Get call.
+type GetResult struct {
+    gophercloud.Result
+}
+
 // ExtractToken returns the just-created Token from a CreateResult.
 func (result CreateResult) ExtractToken() (*Token, error) {
 	if result.Err != nil {

--- a/openstack/identity/v2/tokens/urls.go
+++ b/openstack/identity/v2/tokens/urls.go
@@ -6,3 +6,8 @@ import "github.com/rackspace/gophercloud"
 func CreateURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tokens")
 }
+
+// CreateGetURL generates the URL used to Validate Tokens.
+func CreateGetURL(client *gophercloud.ServiceClient, token string) string {
+    return client.ServiceURL("tokens", token)
+}

--- a/openstack/identity/v2/tokens/urls.go
+++ b/openstack/identity/v2/tokens/urls.go
@@ -7,7 +7,7 @@ func CreateURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tokens")
 }
 
-// CreateGetURL generates the URL used to Validate Tokens.
-func CreateGetURL(client *gophercloud.ServiceClient, token string) string {
-    return client.ServiceURL("tokens", token)
+// GetURL generates the URL used to Validate Tokens.
+func GetURL(client *gophercloud.ServiceClient, token string) string {
+	return client.ServiceURL("tokens", token)
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -185,10 +185,21 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		if client.ReauthFunc != nil {
-			err = client.ReauthFunc()
+			// make sure ReauthFunc only exec one time, or will occur endless recursive loop when admin reauth fail
+			execFunc := client.ReauthFunc
+			client.ReauthFunc = nil
+			err = execFunc()
+			client.ReauthFunc = execFunc
 			if err != nil {
 				return nil, fmt.Errorf("Error trying to re-authenticate: %s", err)
 			}
+
+			if options.MoreHeaders != nil {
+				options.MoreHeaders["X-Auth-Token"] = client.TokenID
+			} else {
+				options.MoreHeaders = client.AuthenticatedHeaders()
+			}
+
 			if options.RawBody != nil {
 				options.RawBody.Seek(0, 0)
 			}


### PR DESCRIPTION
1. Now keystone v2's identity has only a `Create()` method, but we need to use v2's api for dynamic auth k8s, so I add a `Get()` method.
2. The `reauth` in client.go always fail because it forget to clear the expire X-Auth-Token and should reset after reauth successful,  also the recursive `ReauthFunc` will never end if the admin reauth fail, so it need to clear the `ReauthFunc` pointer before executing `ReauthFunc` and restore after that. 