### PR TITLE
Update provider_client.go

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -177,6 +177,9 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 		}
 	}
 
+	// Set connection parameter to close the connection immediately when we've got the response
+	req.Close = true
+	
 	// Issue the request.
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
This change prevents errors "error waiting for instance to become ready" while deploying VMs in Openstack 
(when using Terraform, which requires gophercloud to talk to OpenStack), e.g.:

openstack_compute_instance_v2.myhost: Error waiting for instance (1255de52-e602-4e0a-804c-b2524a404e6f) to become ready: Get https://my.openstack.com:8774/v2/e2678cb5fa304d7c897d156c19261f00/servers/1255de52-e602-4e0a-804c-b2524a404e6f: EOF