### PR TITLE
Bug fix reauth and add extract user from token

### DIFF
--- a/acceptance/openstack/identity/v2/token_test.go
+++ b/acceptance/openstack/identity/v2/token_test.go
@@ -9,7 +9,8 @@ import (
 	th "github.com/rackspace/gophercloud/testhelper"
 )
 
-func TestAuthenticate(t *testing.T) {
+func TestAuthenticateAndValidate(t *testing.T) {
+	// 1. TestAuthenticate
 	ao := v2AuthOptions(t)
 	service := unauthenticatedClient(t)
 
@@ -35,4 +36,19 @@ func TestAuthenticate(t *testing.T) {
 			t.Logf("      - region=[%s] publicURL=[%s]", endpoint.Region, endpoint.PublicURL)
 		}
 	}
+
+	// 2. TestValidate
+	client := authenticatedClient(t)
+
+	// Validate Token!
+	getResult := tokens2.Get(client, token.ID)
+
+	// Extract and print the user.
+	user, err := getResult.ExtractUser()
+	th.AssertNoErr(t, err)
+
+	t.Logf("Acquired User: [%s]", user.Name)
+	t.Logf("The User id: [%s]", user.ID)
+	t.Logf("The User username: [%s]", user.UserName)
+	t.Logf("The User roles: [%#v]", user.Roles)
 }

--- a/openstack/client.go
+++ b/openstack/client.go
@@ -167,6 +167,7 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, options gopherc
 
 	if options.AllowReauth {
 		client.ReauthFunc = func() error {
+			client.TokenID = ""
 			return AuthenticateV3(client, options)
 		}
 	}

--- a/openstack/identity/v2/tokens/fixtures.go
+++ b/openstack/identity/v2/tokens/fixtures.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rackspace/gophercloud/openstack/identity/v2/tenants"
 	th "github.com/rackspace/gophercloud/testhelper"
+	thclient "github.com/rackspace/gophercloud/testhelper/client"
 )
 
 // ExpectedToken is the token that should be parsed from TokenCreationResponse.
@@ -52,6 +53,14 @@ var ExpectedServiceCatalog = &ServiceCatalog{
 			},
 		},
 	},
+}
+
+// ExpectedUser is the token that should be parsed from TokenGetResponse.
+var ExpectedUser = &User{
+	ID:       "a530fefc3d594c4ba2693a4ecd6be74e",
+	Name:     "apiserver",
+	Roles:    []Role{{"member"}, {"service"}},
+	UserName: "apiserver",
 }
 
 // TokenCreationResponse is a JSON response that contains ExpectedToken and ExpectedServiceCatalog.
@@ -99,6 +108,39 @@ const TokenCreationResponse = `
 }
 `
 
+// TokenGetResponse is a JSON response that contains ExpectedToken and ExpectedUser.
+const TokenGetResponse = `
+{
+    "access": {
+		"token": {
+			"issued_at": "2014-01-30T15:30:58.000000Z",
+			"expires": "2014-01-31T15:30:58Z",
+			"id": "aaaabbbbccccdddd",
+			"tenant": {
+				"description": "There are many tenants. This one is yours.",
+				"enabled": true,
+				"id": "fc394f2ab2df4114bde39905f800dc57",
+				"name": "test"
+			}
+		},
+        "serviceCatalog": [], 
+		"user": {
+            "id": "a530fefc3d594c4ba2693a4ecd6be74e", 
+            "name": "apiserver", 
+            "roles": [
+                {
+                    "name": "member"
+                }, 
+                {
+                    "name": "service"
+                }
+            ], 
+            "roles_links": [], 
+            "username": "apiserver"
+        }
+    }
+}`
+
 // HandleTokenPost expects a POST against a /tokens handler, ensures that the request body has been
 // constructed properly given certain auth options, and returns the result.
 func HandleTokenPost(t *testing.T, requestJSON string) {
@@ -115,6 +157,19 @@ func HandleTokenPost(t *testing.T, requestJSON string) {
 	})
 }
 
+// HandleTokenGet expects a Get against a /tokens handler, ensures that the request body has been
+// constructed properly given certain auth options, and returns the result.
+func HandleTokenGet(t *testing.T, token string) {
+	th.Mux.HandleFunc("/tokens/"+token, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", thclient.TokenID)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, TokenGetResponse)
+	})
+}
+
 // IsSuccessful ensures that a CreateResult was successful and contains the correct token and
 // service catalog.
 func IsSuccessful(t *testing.T, result CreateResult) {
@@ -125,4 +180,16 @@ func IsSuccessful(t *testing.T, result CreateResult) {
 	serviceCatalog, err := result.ExtractServiceCatalog()
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedServiceCatalog, serviceCatalog)
+}
+
+// GetIsSuccessful ensures that a GetResult was successful and contains the correct token and
+// User Info.
+func GetIsSuccessful(t *testing.T, result GetResult) {
+	token, err := result.ExtractToken()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedToken, token)
+
+	user, err := result.ExtractUser()
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedUser, user)
 }

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -95,8 +95,5 @@ func Get(client *gophercloud.ServiceClient, token string) GetResult {
 	_, result.Err = client.Get(GetURL(client, token), &result.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 203},
 	})
-	if result.Err != nil {
-		return result
-	}
 	return result
 }

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -91,12 +91,12 @@ func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) CreateRe
 
 // Validates and retrieves information for user's token.
 func Get(client *gophercloud.ServiceClient, token string) GetResult {
-    var result GetResult
-    _, result.Err = client.Get(CreateGetURL(client, token), &result.Body, &gophercloud.RequestOpts{
-        OkCodes: []int{200, 203},
-    })
-    if result.Err != nil {
-        return result
-    }
-    return result
+	var result GetResult
+	_, result.Err = client.Get(GetURL(client, token), &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 203},
+	})
+	if result.Err != nil {
+		return result
+	}
+	return result
 }

--- a/openstack/identity/v2/tokens/requests.go
+++ b/openstack/identity/v2/tokens/requests.go
@@ -88,3 +88,15 @@ func Create(client *gophercloud.ServiceClient, auth AuthOptionsBuilder) CreateRe
 	})
 	return result
 }
+
+// Validates and retrieves information for user's token.
+func Get(client *gophercloud.ServiceClient, token string) GetResult {
+    var result GetResult
+    _, result.Err = client.Get(CreateGetURL(client, token), &result.Body, &gophercloud.RequestOpts{
+        OkCodes: []int{200, 203},
+    })
+    if result.Err != nil {
+        return result
+    }
+    return result
+}

--- a/openstack/identity/v2/tokens/requests_test.go
+++ b/openstack/identity/v2/tokens/requests_test.go
@@ -139,3 +139,14 @@ func TestRequirePassword(t *testing.T) {
 
 	tokenPostErr(t, options, ErrPasswordRequired)
 }
+
+func tokenGet(t *testing.T, tokenId string) GetResult {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleTokenGet(t, tokenId)
+	return Get(client.ServiceClient(), tokenId)
+}
+
+func TestGetWithToken(t *testing.T) {
+	GetIsSuccessful(t, tokenGet(t, "db22caf43c934e6c829087c41ff8d8d6"))
+}

--- a/openstack/identity/v2/tokens/results.go
+++ b/openstack/identity/v2/tokens/results.go
@@ -74,6 +74,11 @@ type CreateResult struct {
 	gophercloud.Result
 }
 
+// GetResult is the deferred response from a Get call.
+type GetResult struct {
+    gophercloud.Result
+}
+
 // ExtractToken returns the just-created Token from a CreateResult.
 func (result CreateResult) ExtractToken() (*Token, error) {
 	if result.Err != nil {

--- a/openstack/identity/v2/tokens/urls.go
+++ b/openstack/identity/v2/tokens/urls.go
@@ -6,3 +6,8 @@ import "github.com/rackspace/gophercloud"
 func CreateURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tokens")
 }
+
+// CreateGetURL generates the URL used to Validate Tokens.
+func CreateGetURL(client *gophercloud.ServiceClient, token string) string {
+    return client.ServiceURL("tokens", token)
+}

--- a/openstack/identity/v2/tokens/urls.go
+++ b/openstack/identity/v2/tokens/urls.go
@@ -7,7 +7,7 @@ func CreateURL(client *gophercloud.ServiceClient) string {
 	return client.ServiceURL("tokens")
 }
 
-// CreateGetURL generates the URL used to Validate Tokens.
-func CreateGetURL(client *gophercloud.ServiceClient, token string) string {
-    return client.ServiceURL("tokens", token)
+// GetURL generates the URL used to Validate Tokens.
+func GetURL(client *gophercloud.ServiceClient, token string) string {
+	return client.ServiceURL("tokens", token)
 }

--- a/provider_client.go
+++ b/provider_client.go
@@ -185,10 +185,21 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		if client.ReauthFunc != nil {
-			err = client.ReauthFunc()
+			// make sure ReauthFunc only exec one time, or will occur endless recursive loop when admin reauth fail
+			execFunc := client.ReauthFunc
+			client.ReauthFunc = nil
+			err = execFunc()
+			client.ReauthFunc = execFunc
 			if err != nil {
 				return nil, fmt.Errorf("Error trying to re-authenticate: %s", err)
 			}
+
+			if options.MoreHeaders != nil {
+				options.MoreHeaders["X-Auth-Token"] = client.TokenID
+			} else {
+				options.MoreHeaders = client.AuthenticatedHeaders()
+			}
+
 			if options.RawBody != nil {
 				options.RawBody.Seek(0, 0)
 			}

--- a/provider_client.go
+++ b/provider_client.go
@@ -185,21 +185,10 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		if client.ReauthFunc != nil {
-			// make sure ReauthFunc only exec one time, or will occur endless recursive loop when admin reauth fail
-			execFunc := client.ReauthFunc
-			client.ReauthFunc = nil
-			err = execFunc()
-			client.ReauthFunc = execFunc
+			err = client.ReauthFunc()
 			if err != nil {
 				return nil, fmt.Errorf("Error trying to re-authenticate: %s", err)
 			}
-
-			if options.MoreHeaders != nil {
-				options.MoreHeaders["X-Auth-Token"] = client.TokenID
-			} else {
-				options.MoreHeaders = client.AuthenticatedHeaders()
-			}
-
 			if options.RawBody != nil {
 				options.RawBody.Seek(0, 0)
 			}


### PR DESCRIPTION
Modifed according to @jrperritt suggestions. the old pull request see https://github.com/rackspace/gophercloud/pull/508 which has beed

1. Clear the auth-token in the reauth function.

2. Add extract user from validate token's repsonse including unit and acceptance tests.