### PR TITLE
Fixed problem re-authenticating during request

### DIFF
--- a/provider_client.go
+++ b/provider_client.go
@@ -197,6 +197,8 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 			if err != nil {
 				return nil, fmt.Errorf("Successfully re-authenticated, but got error executing request: %s", err)
 			}
+
+			return resp, nil
 		}
 	}
 


### PR DESCRIPTION
This commit fixes the nested re-auth logic where it was not
properly returning the response and causing a nil body to
be attempted to be read.

The error being returned was "http invalid read on closed 
request body".