### PR TITLE
[rfr] Allow all routes to be removed from a Neutron router

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -110,7 +110,7 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 		Name         *string      `json:"name,omitempty"`
 		AdminStateUp *bool        `json:"admin_state_up,omitempty"`
 		GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
-		Routes       []Route      `json:"routes,omitempty"`
+		Routes       []Route      `json:"routes"`
 	}
 
 	type request struct {


### PR DESCRIPTION
Remove omitempty tag so an empty Routes array will be passed in JSON
request and all routes can be removed.