### PR TITLE
[WIP] Add missing attributes to GatewayInfo

### DIFF
--- a/openstack/networking/v2/extensions/layer3/routers/requests.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests.go
@@ -61,12 +61,16 @@ type CreateOpts struct {
 // an external network (it is external if its `router:external' field is set to
 // true).
 func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
+	type gatewayinfo struct {
+		NetworkID *string `json:"network_id,omitempty"`
+	}
+
 	type router struct {
 		Name         *string      `json:"name,omitempty"`
 		AdminStateUp *bool        `json:"admin_state_up,omitempty"`
 		Distributed  *bool        `json:"distributed,omitempty"`
 		TenantID     *string      `json:"tenant_id,omitempty"`
-		GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
+		GatewayInfo  *gatewayinfo `json:"external_gateway_info,omitempty"`
 	}
 
 	type request struct {
@@ -81,7 +85,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 	}}
 
 	if opts.GatewayInfo != nil {
-		reqBody.Router.GatewayInfo = opts.GatewayInfo
+		reqBody.Router.GatewayInfo = &gatewayinfo{NetworkID: gophercloud.MaybeString(opts.GatewayInfo.NetworkID)}
 	}
 
 	var res CreateResult
@@ -111,11 +115,15 @@ type UpdateOpts struct {
 // the update of router interfaces. To do this, use the AddInterface and
 // RemoveInterface functions.
 func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResult {
+	type gatewayinfo struct {
+		NetworkID *string `json:"network_id,omitempty"`
+	}
+
 	type router struct {
 		Name         *string      `json:"name,omitempty"`
 		AdminStateUp *bool        `json:"admin_state_up,omitempty"`
 		Distributed  *bool        `json:"distributed,omitempty"`
-		GatewayInfo  *GatewayInfo `json:"external_gateway_info,omitempty"`
+		GatewayInfo  *gatewayinfo `json:"external_gateway_info,omitempty"`
 		Routes       []Route      `json:"routes"`
 	}
 
@@ -130,7 +138,7 @@ func Update(c *gophercloud.ServiceClient, id string, opts UpdateOpts) UpdateResu
 	}}
 
 	if opts.GatewayInfo != nil {
-		reqBody.Router.GatewayInfo = opts.GatewayInfo
+		reqBody.Router.GatewayInfo = &gatewayinfo{NetworkID: gophercloud.MaybeString(opts.GatewayInfo.NetworkID)}
 	}
 
 	if opts.Routes != nil {

--- a/openstack/networking/v2/extensions/layer3/routers/requests_test.go
+++ b/openstack/networking/v2/extensions/layer3/routers/requests_test.go
@@ -50,6 +50,24 @@ func TestList(t *testing.T) {
             "tenant_id": "33a40233088643acb66ff6eb0ebea679",
             "distributed": false,
             "id": "a9254bdb-2613-4a13-ac4c-adc581fba50d"
+        },
+        {
+            "status": "ACTIVE",
+            "external_gateway_info": {
+                "network_id": "c659581f-fc9b-4916-a41a-492ebccc55c2",
+                "enable_snat": true,
+                "external_fixed_ips": [
+                    {
+                        "subnet_id": "54d6f61d-db07-451c-9ab3-b9609b6b6f0b",
+                        "ip_address": "10.0.0.1"
+                    }
+                ]
+            },
+            "name": "router2",
+            "admin_state_up": true,
+            "tenant_id": "007215ed563f42d6980da58bec79df0c",
+            "distributed": false,
+            "id": "e3c4039d-a462-4897-be8d-4ee023a4bc25"
         }
     ]
 }
@@ -84,6 +102,21 @@ func TestList(t *testing.T) {
 				Name:         "router1",
 				ID:           "a9254bdb-2613-4a13-ac4c-adc581fba50d",
 				TenantID:     "33a40233088643acb66ff6eb0ebea679",
+			},
+			Router{
+				Status: "ACTIVE",
+				GatewayInfo: GatewayInfo{
+					NetworkID:  "c659581f-fc9b-4916-a41a-492ebccc55c2",
+					EnableSnat: true,
+					FixedIPs: []IP{
+						IP{SubnetID: "54d6f61d-db07-451c-9ab3-b9609b6b6f0b", IPAddress: "10.0.0.1"},
+					},
+				},
+				AdminStateUp: true,
+				Distributed:  false,
+				Name:         "router2",
+				ID:           "e3c4039d-a462-4897-be8d-4ee023a4bc25",
+				TenantID:     "007215ed563f42d6980da58bec79df0c",
 			},
 		}
 

--- a/openstack/networking/v2/extensions/layer3/routers/results.go
+++ b/openstack/networking/v2/extensions/layer3/routers/results.go
@@ -6,10 +6,24 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
+// IP represents the subnet ID/address pair for the external gateway fixed ip
+type IP struct {
+	SubnetID  string `json:"subnet_id" mapstructure:"subnet_id"`
+	IPAddress string `json:"ip_address" mapstructure:"ip_address"`
+}
+
 // GatewayInfo represents the information of an external gateway for any
 // particular network router.
 type GatewayInfo struct {
+	// Indicates the external network ID for this gateway (read/write)
 	NetworkID string `json:"network_id" mapstructure:"network_id"`
+
+	// Indicates whether the gateway is performing SNAT for instances
+	// without a floating IP (read-only)
+	EnableSnat bool `json:"enable_snat" mapstructure:"enable_snat"`
+
+	// Fixed IPs bound to this gateway (read-only)
+	FixedIPs []IP `json:"external_fixed_ips" mapstructure:"external_fixed_ips"`
 }
 
 type Route struct {


### PR DESCRIPTION
The `GatewayInfo` struct for a Neutron router is missing a few attributes returned by the Neutron routers API:
- `enable_snat` - which controls whether a given router performs SNAT for instances not bound to a floating IP
- `external_fixed_ips` - a list of subnet id/IP address pairs for each external address of this network

Given that `GatewayInfo` is used as part of the public API of gophercloud for Neutron routers, I slightly altered the Create and Update functions to discard the new attributes so that there would be no API breakage. I'm not really proud of the way it's done, though, but I didn't really want to introduce a `GatewayInfoOpts` struct for Create and Update at this point since that would break the public API.

TL;DR: feedback welcome :-)
