### PR TITLE
[RFR] Rackspace Auto Scale: webhooks

### DIFF
--- a/rackspace/autoscale/v1/webhooks/doc.go
+++ b/rackspace/autoscale/v1/webhooks/doc.go
@@ -1,0 +1,11 @@
+/*
+Package webhooks provides information and interaction with the webhook API resource
+in the Rackspace Auto Scale service.
+
+Auto Scale uses webhooks to initiate scaling events.  Webhooks are associated
+with scaling policies and provide capability URLs which can be accessed
+anonymously to trigger execution of those policies.  The Auto Scale webhook
+architecture allows Auto Scale to be integrated with other systems, for example,
+monitoring systems.
+*/
+package webhooks

--- a/rackspace/autoscale/v1/webhooks/fixtures.go
+++ b/rackspace/autoscale/v1/webhooks/fixtures.go
@@ -205,7 +205,22 @@ func HandleWebhookUpdateSuccessfully(t *testing.T) {
 
 		th.TestJSONRequest(t, r, WebhookUpdateRequest)
 
-		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// HandleWebhookDeleteSuccessfully sets up the test server to respond to a webhooks Delete request.
+func HandleWebhookDeleteSuccessfully(t *testing.T) {
+	groupID := "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
+	policyID := "2b48d247-0282-4b9d-8775-5c4b67e8e649"
+	webhookID := "2bd1822c-58c5-49fd-8b3d-ed44781a58d1"
+
+	path := fmt.Sprintf("/groups/%s/policies/%s/webhooks/%s", groupID, policyID, webhookID)
+
+	th.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
 		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/rackspace/autoscale/v1/webhooks/fixtures.go
+++ b/rackspace/autoscale/v1/webhooks/fixtures.go
@@ -92,6 +92,16 @@ const WebhookGetBody = `
 }
 `
 
+// WebhookUpdateRequest contains the canned body of a webhooks.Update request.
+const WebhookUpdateRequest = `
+{
+  "name": "updated hook",
+  "metadata": {
+    "new-key": "some data"
+  }
+}
+`
+
 var (
 	// FirstWebhook is a Webhook corresponding to the first result in WebhookListBody.
 	FirstWebhook = Webhook{
@@ -178,5 +188,24 @@ func HandleWebhookGetSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		fmt.Fprintf(w, WebhookGetBody)
+	})
+}
+
+// HandleWebhookUpdateSuccessfully sets up the test server to respond to a webhooks Update request.
+func HandleWebhookUpdateSuccessfully(t *testing.T) {
+	groupID := "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
+	policyID := "2b48d247-0282-4b9d-8775-5c4b67e8e649"
+	webhookID := "2bd1822c-58c5-49fd-8b3d-ed44781a58d1"
+
+	path := fmt.Sprintf("/groups/%s/policies/%s/webhooks/%s", groupID, policyID, webhookID)
+
+	th.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		th.TestJSONRequest(t, r, WebhookUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/rackspace/autoscale/v1/webhooks/fixtures.go
+++ b/rackspace/autoscale/v1/webhooks/fixtures.go
@@ -1,0 +1,106 @@
+// +build fixtures
+
+package webhooks
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/rackspace/gophercloud"
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+// WebhookListBody contains the canned body of a webhooks.List response.
+const WebhookListBody = `
+{
+  "webhooks": [
+    {
+      "id": "2bd1822c-58c5-49fd-8b3d-ed44781a58d1",
+      "name": "first hook",
+      "links": [
+        {
+          "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/123456/groups/60b15dad-5ea1-43fa-9a12-a1d737b4da07/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks/2bd1822c-58c5-49fd-8b3d-ed44781a58d1/",
+          "rel": "self"
+        },
+        {
+          "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/execute/1/714c1c17c5e6ea5ef1e710d5ccc62e492575bab5216184d4c27dc0164db1bc06/",
+          "rel": "capability"
+        }
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "76711c36-dfbe-4f5e-bea6-cded99690515",
+      "name": "second hook",
+      "links": [
+        {
+          "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/123456/groups/60b15dad-5ea1-43fa-9a12-a1d737b4da07/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks/76711c36-dfbe-4f5e-bea6-cded99690515/",
+          "rel": "self"
+        },
+        {
+          "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/execute/1/982e24858723f9e8bc2afea42a73a3c357c8f518857735400a7f7d8b3f14ccdb/",
+          "rel": "capability"
+        }
+      ],
+      "metadata": {
+        "notes": "a note about this webhook"
+      }
+    }
+  ],
+  "webhooks_links": []
+}
+`
+
+var (
+	// FirstWebhook is a Webhook corresponding to the first result in WebhookListBody.
+	FirstWebhook = Webhook{
+		ID:   "2bd1822c-58c5-49fd-8b3d-ed44781a58d1",
+		Name: "first hook",
+		Links: []gophercloud.Link{
+			{
+				Href: "https://dfw.autoscale.api.rackspacecloud.com/v1.0/123456/groups/60b15dad-5ea1-43fa-9a12-a1d737b4da07/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks/2bd1822c-58c5-49fd-8b3d-ed44781a58d1/",
+				Rel:  "self",
+			},
+			{
+				Href: "https://dfw.autoscale.api.rackspacecloud.com/v1.0/execute/1/714c1c17c5e6ea5ef1e710d5ccc62e492575bab5216184d4c27dc0164db1bc06/",
+				Rel:  "capability",
+			},
+		},
+		Metadata: map[string]string{},
+	}
+
+	// SecondWebhook is a Webhook corresponding to the second result in WebhookListBody.
+	SecondWebhook = Webhook{
+		ID:   "76711c36-dfbe-4f5e-bea6-cded99690515",
+		Name: "second hook",
+		Links: []gophercloud.Link{
+			{
+				Href: "https://dfw.autoscale.api.rackspacecloud.com/v1.0/123456/groups/60b15dad-5ea1-43fa-9a12-a1d737b4da07/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks/76711c36-dfbe-4f5e-bea6-cded99690515/",
+				Rel:  "self",
+			},
+			{
+				Href: "https://dfw.autoscale.api.rackspacecloud.com/v1.0/execute/1/982e24858723f9e8bc2afea42a73a3c357c8f518857735400a7f7d8b3f14ccdb/",
+				Rel:  "capability",
+			},
+		},
+		Metadata: map[string]string{
+			"notes": "a note about this webhook",
+		},
+	}
+)
+
+// HandleWebhookListSuccessfully sets up the test server to respond to a webhooks List request.
+func HandleWebhookListSuccessfully(t *testing.T) {
+	path := "/groups/10eb3219-1b12-4b34-b1e4-e10ee4f24c65/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks"
+
+	th.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		fmt.Fprintf(w, WebhookListBody)
+	})
+}

--- a/rackspace/autoscale/v1/webhooks/fixtures.go
+++ b/rackspace/autoscale/v1/webhooks/fixtures.go
@@ -53,6 +53,24 @@ const WebhookListBody = `
 }
 `
 
+// WebhookCreateBody contains the canned body of a webhooks.Create response.
+const WebhookCreateBody = WebhookListBody
+
+// WebhookCreateRequest contains the canned body of a webhooks.Create request.
+const WebhookCreateRequest = `
+[
+  {
+    "name": "first hook"
+  },
+  {
+    "name": "second hook",
+    "metadata": {
+      "notes": "a note about this webhook"
+    }
+  }
+]
+`
+
 var (
 	// FirstWebhook is a Webhook corresponding to the first result in WebhookListBody.
 	FirstWebhook = Webhook{
@@ -102,5 +120,24 @@ func HandleWebhookListSuccessfully(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 
 		fmt.Fprintf(w, WebhookListBody)
+	})
+}
+
+// HandleWebhookCreateSuccessfully sets up the test server to respond to a webhooks Create request.
+func HandleWebhookCreateSuccessfully(t *testing.T) {
+	path := "/groups/10eb3219-1b12-4b34-b1e4-e10ee4f24c65/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks"
+
+	th.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		th.TestJSONRequest(t, r, WebhookCreateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprintf(w, WebhookCreateBody)
 	})
 }

--- a/rackspace/autoscale/v1/webhooks/fixtures.go
+++ b/rackspace/autoscale/v1/webhooks/fixtures.go
@@ -71,6 +71,27 @@ const WebhookCreateRequest = `
 ]
 `
 
+// WebhookGetBody contains the canned body of a webhooks.Get response.
+const WebhookGetBody = `
+{
+  "webhook": {
+    "id": "2bd1822c-58c5-49fd-8b3d-ed44781a58d1",
+    "name": "first hook",
+    "links": [
+      {
+        "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/123456/groups/60b15dad-5ea1-43fa-9a12-a1d737b4da07/policies/2b48d247-0282-4b9d-8775-5c4b67e8e649/webhooks/2bd1822c-58c5-49fd-8b3d-ed44781a58d1/",
+        "rel": "self"
+      },
+      {
+        "href": "https://dfw.autoscale.api.rackspacecloud.com/v1.0/execute/1/714c1c17c5e6ea5ef1e710d5ccc62e492575bab5216184d4c27dc0164db1bc06/",
+        "rel": "capability"
+      }
+    ],
+    "metadata": {}
+  }
+}
+`
+
 var (
 	// FirstWebhook is a Webhook corresponding to the first result in WebhookListBody.
 	FirstWebhook = Webhook{
@@ -139,5 +160,23 @@ func HandleWebhookCreateSuccessfully(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 
 		fmt.Fprintf(w, WebhookCreateBody)
+	})
+}
+
+// HandleWebhookGetSuccessfully sets up the test server to respond to a webhooks Get request.
+func HandleWebhookGetSuccessfully(t *testing.T) {
+	groupID := "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
+	policyID := "2b48d247-0282-4b9d-8775-5c4b67e8e649"
+	webhookID := "2bd1822c-58c5-49fd-8b3d-ed44781a58d1"
+
+	path := fmt.Sprintf("/groups/%s/policies/%s/webhooks/%s", groupID, policyID, webhookID)
+
+	th.Mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+
+		fmt.Fprintf(w, WebhookGetBody)
 	})
 }

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -1,0 +1,17 @@
+package webhooks
+
+import (
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+// List returns all webhooks for a scaling policy.
+func List(client *gophercloud.ServiceClient, groupID, policyID string) pagination.Pager {
+	url := listURL(client, groupID, policyID)
+
+	createPageFn := func(r pagination.PageResult) pagination.Page {
+		return WebhookPage{pagination.SinglePageBase(r)}
+	}
+
+	return pagination.NewPager(client, url, createPageFn)
+}

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -153,3 +153,15 @@ func Update(client *gophercloud.ServiceClient, groupID, policyID, webhookID stri
 
 	return result
 }
+
+// Delete requests the given webhook be permanently deleted.
+func Delete(client *gophercloud.ServiceClient, groupID, policyID, webhookID string) DeleteResult {
+	var result DeleteResult
+
+	url := deleteURL(client, groupID, policyID, webhookID)
+	_, result.Err = client.Delete(url, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+
+	return result
+}

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -78,15 +78,9 @@ func Create(client *gophercloud.ServiceClient, groupID, policyID string, opts Cr
 		return res
 	}
 
-	resp, err := client.Post(createURL(client, groupID, policyID), reqBody, &res.Body, nil)
+	_, res.Err = client.Post(createURL(client, groupID, policyID), reqBody, &res.Body, nil)
 
-	if err != nil {
-		res.Err = err
-		return res
-	}
-
-	pr := pagination.PageResultFromParsed(resp, res.Body)
-	return CreateResult{pagination.SinglePageBase(pr)}
+	return res
 }
 
 // Get requests the details of a single webhook with the given ID.

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -84,3 +84,12 @@ func Create(client *gophercloud.ServiceClient, groupID, policyID string, opts Cr
 	pr := pagination.PageResultFromParsed(resp, res.Body)
 	return CreateResult{pagination.SinglePageBase(pr)}
 }
+
+// Get requests the details of a single webhook with the given ID.
+func Get(client *gophercloud.ServiceClient, groupID, policyID, webhookID string) GetResult {
+	var result GetResult
+
+	_, result.Err = client.Get(getURL(client, groupID, policyID, webhookID), &result.Body, nil)
+
+	return result
+}

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -7,9 +7,11 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
-// ErrNoName represents a validation error in which a create or update operation
-// has an empty name field.
-var ErrNoName = errors.New("Webhook name cannot by empty.")
+// Validation errors returned by create or update operations.
+var (
+	ErrNoName     = errors.New("Webhook name cannot by empty.")
+	ErrNoMetadata = errors.New("Webhook metadata cannot be nil.")
+)
 
 // List returns all webhooks for a scaling policy.
 func List(client *gophercloud.ServiceClient, groupID, policyID string) pagination.Pager {
@@ -118,13 +120,14 @@ func (opts UpdateOpts) ToWebhookUpdateMap() (map[string]interface{}, error) {
 		return nil, ErrNoName
 	}
 
+	if opts.Metadata == nil {
+		return nil, ErrNoMetadata
+	}
+
 	hook := make(map[string]interface{})
 
 	hook["name"] = opts.Name
-
-	if opts.Metadata != nil {
-		hook["metadata"] = opts.Metadata
-	}
+	hook["metadata"] = opts.Metadata
 
 	return hook, nil
 }

--- a/rackspace/autoscale/v1/webhooks/requests.go
+++ b/rackspace/autoscale/v1/webhooks/requests.go
@@ -1,6 +1,8 @@
 package webhooks
 
 import (
+	"errors"
+
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/pagination"
 )
@@ -14,4 +16,71 @@ func List(client *gophercloud.ServiceClient, groupID, policyID string) paginatio
 	}
 
 	return pagination.NewPager(client, url, createPageFn)
+}
+
+// CreateOptsBuilder is the interface responsible for generating the JSON
+// for a Create operation.
+type CreateOptsBuilder interface {
+	ToWebhookCreateMap() ([]map[string]interface{}, error)
+}
+
+// CreateOpts is a slice of CreateOpt structs, that allow the user to create
+// multiple webhooks in a single operation.
+type CreateOpts []CreateOpt
+
+// CreateOpt represents the options to create a webhook.
+type CreateOpt struct {
+	// Name [required] is a name for the webhook.
+	Name string
+
+	// Metadata [optional] is user-provided key-value metadata.
+	// Maximum length for keys and values is 256 characters.
+	Metadata map[string]string
+}
+
+// ToWebhookCreateMap converts a slice of CreateOpt structs into a map for use
+// in the request body of a Create operation.
+func (opts CreateOpts) ToWebhookCreateMap() ([]map[string]interface{}, error) {
+	var webhooks []map[string]interface{}
+
+	for _, o := range opts {
+		if o.Name == "" {
+			return nil, errors.New("Cannot create a Webhook without a name.")
+		}
+
+		hook := make(map[string]interface{})
+
+		hook["name"] = o.Name
+
+		if o.Metadata != nil {
+			hook["metadata"] = o.Metadata
+		}
+
+		webhooks = append(webhooks, hook)
+	}
+
+	return webhooks, nil
+}
+
+// Create requests a new webhook be created and associated with the given group
+// and scaling policy.
+func Create(client *gophercloud.ServiceClient, groupID, policyID string, opts CreateOptsBuilder) CreateResult {
+	var res CreateResult
+
+	reqBody, err := opts.ToWebhookCreateMap()
+
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	resp, err := client.Post(createURL(client, groupID, policyID), reqBody, &res.Body, nil)
+
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	pr := pagination.PageResultFromParsed(resp, res.Body)
+	return CreateResult{pagination.SinglePageBase(pr)}
 }

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -104,3 +104,14 @@ func TestUpdate(t *testing.T) {
 
 	th.AssertNoErr(t, err)
 }
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleWebhookDeleteSuccessfully(t)
+
+	client := client.ServiceClient()
+	err := Delete(client, groupID, policyID, firstID).ExtractErr()
+
+	th.AssertNoErr(t, err)
+}

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -105,6 +105,21 @@ func TestUpdate(t *testing.T) {
 	th.AssertNoErr(t, err)
 }
 
+func TestUpdateNoMetadata(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleWebhookUpdateSuccessfully(t)
+
+	client := client.ServiceClient()
+	opts := UpdateOpts{
+		Name: "updated hook",
+	}
+
+	err := Update(client, groupID, policyID, firstID, opts).ExtractErr()
+
+	th.AssertEquals(t, ErrNoMetadata, err)
+}
+
 func TestDelete(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -86,3 +86,21 @@ func TestGet(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, FirstWebhook, *webhook)
 }
+
+func TestUpdate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleWebhookUpdateSuccessfully(t)
+
+	client := client.ServiceClient()
+	opts := UpdateOpts{
+		Name: "updated hook",
+		Metadata: map[string]string{
+			"new-key": "some data",
+		},
+	}
+
+	err := Update(client, groupID, policyID, firstID, opts).ExtractErr()
+
+	th.AssertNoErr(t, err)
+}

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -67,7 +67,7 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	webhooks, err := Create(client, groupID, policyID, opts).ExtractWebhooks()
+	webhooks, err := Create(client, groupID, policyID, opts).Extract()
 
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, FirstWebhook, webhooks[0])

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -11,6 +11,8 @@ import (
 const (
 	groupID  = "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
 	policyID = "2b48d247-0282-4b9d-8775-5c4b67e8e649"
+	firstID  = "2bd1822c-58c5-49fd-8b3d-ed44781a58d1" // FirstWebhook
+	secondID = "76711c36-dfbe-4f5e-bea6-cded99690515" // SecondWebhook
 )
 
 func TestList(t *testing.T) {
@@ -70,4 +72,17 @@ func TestCreate(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, FirstWebhook, webhooks[0])
 	th.CheckDeepEquals(t, SecondWebhook, webhooks[1])
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleWebhookGetSuccessfully(t)
+
+	client := client.ServiceClient()
+
+	webhook, err := Get(client, groupID, policyID, firstID).Extract()
+
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FirstWebhook, *webhook)
 }

--- a/rackspace/autoscale/v1/webhooks/requests_test.go
+++ b/rackspace/autoscale/v1/webhooks/requests_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/rackspace/gophercloud/testhelper/client"
 )
 
+const (
+	groupID  = "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
+	policyID = "2b48d247-0282-4b9d-8775-5c4b67e8e649"
+)
+
 func TestList(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 	HandleWebhookListSuccessfully(t)
-
-	groupID := "10eb3219-1b12-4b34-b1e4-e10ee4f24c65"
-	policyID := "2b48d247-0282-4b9d-8775-5c4b67e8e649"
 
 	pages := 0
 	pager := List(client.ServiceClient(), groupID, policyID)
@@ -43,4 +45,29 @@ func TestList(t *testing.T) {
 	if pages != 1 {
 		t.Errorf("Expected 1 page, saw %d", pages)
 	}
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleWebhookCreateSuccessfully(t)
+
+	client := client.ServiceClient()
+	opts := CreateOpts{
+		{
+			Name: "first hook",
+		},
+		{
+			Name: "second hook",
+			Metadata: map[string]string{
+				"notes": "a note about this webhook",
+			},
+		},
+	}
+
+	webhooks, err := Create(client, groupID, policyID, opts).ExtractWebhooks()
+
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, FirstWebhook, webhooks[0])
+	th.CheckDeepEquals(t, SecondWebhook, webhooks[1])
 }

--- a/rackspace/autoscale/v1/webhooks/results.go
+++ b/rackspace/autoscale/v1/webhooks/results.go
@@ -34,11 +34,6 @@ type CreateResult struct {
 	pagination.SinglePageBase
 }
 
-// GetResult temporarily contains the response from a Get call.
-type GetResult struct {
-	webhookResult
-}
-
 // ExtractWebhooks extracts a slice of Webhooks from a CreateResult.
 func (res CreateResult) ExtractWebhooks() ([]Webhook, error) {
 	if res.Err != nil {
@@ -46,6 +41,16 @@ func (res CreateResult) ExtractWebhooks() ([]Webhook, error) {
 	}
 
 	return commonExtractWebhooks(res.Body)
+}
+
+// GetResult temporarily contains the response from a Get call.
+type GetResult struct {
+	webhookResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	gophercloud.ErrResult
 }
 
 // Webhook represents a webhook associted with a scaling policy.

--- a/rackspace/autoscale/v1/webhooks/results.go
+++ b/rackspace/autoscale/v1/webhooks/results.go
@@ -1,0 +1,62 @@
+package webhooks
+
+import (
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+type webhookResult struct {
+	gophercloud.Result
+}
+
+// Webhook represents a webhook associted with a scaling policy.
+type Webhook struct {
+	// UUID for the webhook.
+	ID string `mapstructure:"id" json:"id"`
+
+	// Name of the webhook.
+	Name string `mapstructure:"name" json:"name"`
+
+	// Links associated with the webhook, including the capability URL.
+	Links []gophercloud.Link `mapstructure:"links" json:"links"`
+
+	// Metadata associated with the webhook.
+	Metadata map[string]string `mapstructure:"metadata" json:"metadata"`
+}
+
+// WebhookPage is the page returned by a pager when traversing over a collection
+// of webhooks.
+type WebhookPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a page contains no Webhook results.
+func (page WebhookPage) IsEmpty() (bool, error) {
+	hooks, err := ExtractWebhooks(page)
+
+	if err != nil {
+		return true, err
+	}
+
+	return len(hooks) == 0, nil
+}
+
+// ExtractWebhooks interprets the results of a single page from a List() call,
+// producing a slice of Webhooks.
+func ExtractWebhooks(page pagination.Page) ([]Webhook, error) {
+	casted := page.(WebhookPage).Body
+
+	var response struct {
+		Webhooks []Webhook `mapstructure:"webhooks"`
+	}
+
+	err := mapstructure.Decode(casted, &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Webhooks, err
+}

--- a/rackspace/autoscale/v1/webhooks/results.go
+++ b/rackspace/autoscale/v1/webhooks/results.go
@@ -11,12 +11,32 @@ type webhookResult struct {
 	gophercloud.Result
 }
 
+// Extract interprets any webhookResult as a Webhook, if possible.
+func (r webhookResult) Extract() (*Webhook, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	var response struct {
+		Webhook Webhook `mapstructure:"webhook"`
+	}
+
+	err := mapstructure.Decode(r.Body, &response)
+
+	return &response.Webhook, err
+}
+
 // CreateResult represents the result of a create operation. Multiple webhooks
 // can be created in a single call, so the result should be treated as a typical
 // pagination Page.  ExtractWebhooks() can be used to extract a slice of
 // Webhooks from a single page.
 type CreateResult struct {
 	pagination.SinglePageBase
+}
+
+// GetResult temporarily contains the response from a Get call.
+type GetResult struct {
+	webhookResult
 }
 
 // ExtractWebhooks extracts a slice of Webhooks from a CreateResult.

--- a/rackspace/autoscale/v1/webhooks/results.go
+++ b/rackspace/autoscale/v1/webhooks/results.go
@@ -53,6 +53,11 @@ type UpdateResult struct {
 	gophercloud.ErrResult
 }
 
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
 // Webhook represents a webhook associted with a scaling policy.
 type Webhook struct {
 	// UUID for the webhook.

--- a/rackspace/autoscale/v1/webhooks/results.go
+++ b/rackspace/autoscale/v1/webhooks/results.go
@@ -26,16 +26,15 @@ func (r webhookResult) Extract() (*Webhook, error) {
 	return &response.Webhook, err
 }
 
-// CreateResult represents the result of a create operation. Multiple webhooks
-// can be created in a single call, so the result should be treated as a typical
-// pagination Page.  ExtractWebhooks() can be used to extract a slice of
-// Webhooks from a single page.
+// CreateResult represents the result of a create operation.
 type CreateResult struct {
-	pagination.SinglePageBase
+	webhookResult
 }
 
-// ExtractWebhooks extracts a slice of Webhooks from a CreateResult.
-func (res CreateResult) ExtractWebhooks() ([]Webhook, error) {
+// Extract extracts a slice of Webhooks from a CreateResult.  Multiple webhooks
+// can be created in a single operation, so the result of a create is always a
+// list of webhooks.
+func (res CreateResult) Extract() ([]Webhook, error) {
 	if res.Err != nil {
 		return nil, res.Err
 	}

--- a/rackspace/autoscale/v1/webhooks/urls.go
+++ b/rackspace/autoscale/v1/webhooks/urls.go
@@ -13,3 +13,7 @@ func createURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
 func getURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) string {
 	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks", webhookID)
 }
+
+func updateURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) string {
+	return getURL(c, groupID, policyID, webhookID)
+}

--- a/rackspace/autoscale/v1/webhooks/urls.go
+++ b/rackspace/autoscale/v1/webhooks/urls.go
@@ -17,3 +17,7 @@ func getURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) s
 func updateURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) string {
 	return getURL(c, groupID, policyID, webhookID)
 }
+
+func deleteURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) string {
+	return getURL(c, groupID, policyID, webhookID)
+}

--- a/rackspace/autoscale/v1/webhooks/urls.go
+++ b/rackspace/autoscale/v1/webhooks/urls.go
@@ -5,3 +5,7 @@ import "github.com/rackspace/gophercloud"
 func listURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
 	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks")
 }
+
+func createURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
+	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks")
+}

--- a/rackspace/autoscale/v1/webhooks/urls.go
+++ b/rackspace/autoscale/v1/webhooks/urls.go
@@ -9,3 +9,7 @@ func listURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
 func createURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
 	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks")
 }
+
+func getURL(c *gophercloud.ServiceClient, groupID, policyID, webhookID string) string {
+	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks", webhookID)
+}

--- a/rackspace/autoscale/v1/webhooks/urls.go
+++ b/rackspace/autoscale/v1/webhooks/urls.go
@@ -1,0 +1,7 @@
+package webhooks
+
+import "github.com/rackspace/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient, groupID, policyID string) string {
+	return c.ServiceURL("groups", groupID, "policies", policyID, "webhooks")
+}

--- a/rackspace/autoscale/v1/webhooks/urls_test.go
+++ b/rackspace/autoscale/v1/webhooks/urls_test.go
@@ -1,0 +1,44 @@
+package webhooks
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud"
+	th "github.com/rackspace/gophercloud/testhelper"
+)
+
+const endpoint = "http://localhost:57909/"
+
+func endpointClient() *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{Endpoint: endpoint}
+}
+
+func TestListURL(t *testing.T) {
+	actual := listURL(endpointClient(), "123", "456")
+	expected := endpoint + "groups/123/policies/456/webhooks"
+	th.CheckEquals(t, expected, actual)
+}
+
+func TestCreateURL(t *testing.T) {
+	actual := createURL(endpointClient(), "123", "456")
+	expected := endpoint + "groups/123/policies/456/webhooks"
+	th.CheckEquals(t, expected, actual)
+}
+
+func TestGetURL(t *testing.T) {
+	actual := getURL(endpointClient(), "123", "456", "789")
+	expected := endpoint + "groups/123/policies/456/webhooks/789"
+	th.CheckEquals(t, expected, actual)
+}
+
+func TestUpdateURL(t *testing.T) {
+	actual := updateURL(endpointClient(), "123", "456", "789")
+	expected := endpoint + "groups/123/policies/456/webhooks/789"
+	th.CheckEquals(t, expected, actual)
+}
+
+func TestDeleteURL(t *testing.T) {
+	actual := deleteURL(endpointClient(), "123", "456", "789")
+	expected := endpoint + "groups/123/policies/456/webhooks/789"
+	th.CheckEquals(t, expected, actual)
+}

--- a/rackspace/client.go
+++ b/rackspace/client.go
@@ -222,3 +222,13 @@ func NewDBV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*
 	}
 	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url}, nil
 }
+
+// NewAutoScaleV1 creates a ServiceClient that may be used to access the v1 Auto Scale service.
+func NewAutoScaleV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	eo.ApplyDefaults("rax:autoscale")
+	url, err := client.EndpointLocator(eo)
+	if err != nil {
+		return nil, err
+	}
+	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url}, nil
+}


### PR DESCRIPTION
First steps toward supporting Rackspace Auto Scale. Adds a package for [webhook](https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#document-api-operations/autoscale-webhooks) resources.