### PR TITLE
[WIP] Add KeyName option for servers

### DIFF
--- a/openstack/compute/v2/servers/requests.go
+++ b/openstack/compute/v2/servers/requests.go
@@ -183,6 +183,9 @@ type CreateOpts struct {
 
 	// AccessIPv6 [optional] specifies an IPv6 address for the instance.
 	AccessIPv6 string
+
+	// KeyName [optional] is the key pair name for SSH Key-Based authentication.
+	KeyName string
 }
 
 // ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -216,6 +219,9 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 	}
 	if opts.AccessIPv6 != "" {
 		server["accessIPv6"] = opts.AccessIPv6
+	}
+	if opts.KeyName != "" {
+		server["key_name"] = opts.KeyName
 	}
 
 	if len(opts.SecurityGroups) > 0 {


### PR DESCRIPTION
This adds ```KeyName``` property to CreateOpts struct, and It will be able to create the instance with ssh public key.

https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#post-create-server-servers