### PR TITLE
[rfr] Add Provider Option for Pool Creation

### DIFF
--- a/acceptance/openstack/networking/v2/extensions/lbaas/common.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/common.go
@@ -44,6 +44,7 @@ func CreatePool(t *testing.T, subnetID string) string {
 		Protocol: "HTTP",
 		Name:     "tmp_pool",
 		SubnetID: subnetID,
+		Provider: "haproxy",
 	}).Extract()
 
 	th.AssertNoErr(t, err)

--- a/acceptance/openstack/networking/v2/extensions/lbaas/pool_test.go
+++ b/acceptance/openstack/networking/v2/extensions/lbaas/pool_test.go
@@ -55,7 +55,7 @@ func listPools(t *testing.T) {
 		}
 
 		for _, p := range poolList {
-			t.Logf("Listing pool: ID [%s] Name [%s] Status [%s] LB algorithm [%s]", p.ID, p.Name, p.Status, p.LBMethod)
+			t.Logf("Listing pool: ID [%s] Name [%s] Status [%s] LB algorithm [%s] Provider [%s]", p.ID, p.Name, p.Status, p.LBMethod, p.Provider)
 		}
 
 		return true, nil

--- a/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -74,6 +74,9 @@ type CreateOpts struct {
 	// current specification supports LBMethodRoundRobin and
 	// LBMethodLeastConnections as valid values for this attribute.
 	LBMethod string
+
+	// The provider of the pool
+	Provider string
 }
 
 // Create accepts a CreateOpts struct and uses the values to create a new
@@ -85,6 +88,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Protocol string `json:"protocol"`
 		SubnetID string `json:"subnet_id"`
 		LBMethod string `json:"lb_method"`
+		Provider string `json:"provider,omitempty"`
 	}
 	type request struct {
 		Pool pool `json:"pool"`
@@ -96,6 +100,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Protocol: opts.Protocol,
 		SubnetID: opts.SubnetID,
 		LBMethod: opts.LBMethod,
+		Provider: opts.Provider,
 	}}
 
 	var res CreateResult

--- a/openstack/networking/v2/extensions/lbaas/pools/requests_test.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests_test.go
@@ -119,7 +119,8 @@ func TestCreate(t *testing.T) {
         "protocol": "HTTP",
         "name": "Example pool",
         "subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
-        "tenant_id": "2ffc6e22aae24e4795f87155d24c896f"
+        "tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
+        "provider": "haproxy"
     }
 }
 			`)
@@ -143,7 +144,8 @@ func TestCreate(t *testing.T) {
         "admin_state_up": true,
         "subnet_id": "1981f108-3c48-48d2-b908-30f7d28532c9",
         "tenant_id": "2ffc6e22aae24e4795f87155d24c896f",
-        "health_monitors_status": []
+        "health_monitors_status": [],
+        "provider": "haproxy"
     }
 }
 		`)
@@ -155,6 +157,7 @@ func TestCreate(t *testing.T) {
 		Name:     "Example pool",
 		SubnetID: "1981f108-3c48-48d2-b908-30f7d28532c9",
 		TenantID: "2ffc6e22aae24e4795f87155d24c896f",
+		Provider: "haproxy",
 	}
 	p, err := Create(fake.ServiceClient(), options).Extract()
 	th.AssertNoErr(t, err)
@@ -169,6 +172,7 @@ func TestCreate(t *testing.T) {
 	th.AssertEquals(t, "Example pool", p.Name)
 	th.AssertEquals(t, "1981f108-3c48-48d2-b908-30f7d28532c9", p.SubnetID)
 	th.AssertEquals(t, "2ffc6e22aae24e4795f87155d24c896f", p.TenantID)
+	th.AssertEquals(t, "haproxy", p.Provider)
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
This commit adds the ability to specify a provider when creating a
LBaaS pool.

According to https://github.com/hashicorp/terraform/issues/5545, a `Provider` option can be sent during Pool creation. `neutron help lb-pool-create` supports this as well as:

```
neutron --debug lb-pool-create --lb-method ROUND_ROBIN --name foo --protocol HTTP --subnet-id 87e03ccf-4842-45c3-b199-3817f8463103 --provider haproxy

DEBUG: keystoneclient.session REQ: curl -g -i -X POST http://10.1.1.36:9696/v2.0/lb/pools.json -H "User-Agent: python-neutronclient"
-H "Content-Type: application/json" -H "Accept: application/json" -H "X-Auth-Token: {SHA1}8deb61cc7c8014a29d6ba13c01c81245de0c5fcb" 
-d '{"pool": {"lb_method": "ROUND_ROBIN", "protocol": "HTTP", "name": "foo", "admin_state_up": true, "subnet_id": "87e03ccf-4842-45c3-b199-3817f8463103", "provider": "haproxy"}}'
```