### PR TITLE
Add attach/detach blockstorage support

### DIFF
--- a/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -1,0 +1,5 @@
+// Package volumeactions provides special actions on volumes as part of the
+// OpenStack Block Storage service.  Actions are the category of operations
+// that includes things like attach/detach of volumes to a host/instance.
+
+package volumeactions

--- a/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -1,0 +1,154 @@
+package volumeactions
+
+import (
+	"github.com/rackspace/gophercloud"
+)
+
+type ConnectorOptsBuilder interface {
+	ToConnectorMap() (map[string]interface{}, error)
+}
+
+type ConnectorOpts struct {
+	IP        string
+	Host      string
+	Initiator string
+	Wwpns     string
+	Wwnns     string
+	MultiPath bool
+	Platform  string
+	OSType    string
+}
+
+type AttachOpts struct {
+	MountPoint   string
+	InstanceUUID string
+	HostName     string
+	Mode         string
+}
+
+func Reserve(client *gophercloud.ServiceClient, id string) actionsResult {
+	var result actionsResult
+	empty_val := make(map[string]interface{})
+	reqBody := map[string]interface{}{"os-reserve": empty_val}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return result
+}
+
+func (opts ConnectorOpts) ToConnectorMap() (map[string]interface{}, error) {
+	c := make(map[string]interface{})
+
+	if opts.IP != "" {
+		c["ip"] = opts.IP
+	}
+	if opts.Host != "" {
+		c["host"] = opts.Host
+	}
+	if opts.Initiator != "" {
+		c["initiator"] = opts.Initiator
+	}
+	if opts.Wwpns != "" {
+		c["wwpns"] = opts.Wwpns
+	}
+	if opts.Wwnns != "" {
+		c["wwnns"] = opts.Wwnns
+	}
+	if opts.Platform != "" {
+		c["platform"] = opts.Platform
+	}
+	if opts.OSType != "" {
+		c["os_type"] = opts.OSType
+	}
+	c["multipath"] = opts.MultiPath
+	return map[string]interface{}{"connector": c}, nil
+}
+
+func InitializeConnection(client *gophercloud.ServiceClient, id string, opts *ConnectorOpts) actionsResult {
+	var result actionsResult
+	connector, err := opts.ToConnectorMap()
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	reqBody := map[string]interface{}{"os-initialize_connection": connector}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	return result
+}
+
+func (opts AttachOpts) ToAttachMap() (map[string]interface{}, error) {
+	a := make(map[string]interface{})
+
+	if opts.MountPoint != "" {
+		a["mountpoint"] = opts.MountPoint
+	}
+	if opts.Mode != "" {
+		a["mode"] = opts.Mode
+	}
+	if opts.InstanceUUID != "" {
+		a["instance_uuid"] = opts.InstanceUUID
+	}
+	if opts.HostName != "" {
+		a["host_name"] = opts.HostName
+	}
+	return a, nil
+}
+
+func Attach(client *gophercloud.ServiceClient, id string, opts *AttachOpts) actionsResult {
+	var result actionsResult
+	attach, err := opts.ToAttachMap()
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	reqBody := map[string]interface{}{"os-attach": attach}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	return result
+
+}
+
+func UnReserve(client *gophercloud.ServiceClient, id string) actionsResult {
+	var result actionsResult
+	empty_val := make(map[string]interface{})
+	reqBody := map[string]interface{}{"os-unreserve": empty_val}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return result
+}
+
+func TerminateConnection(client *gophercloud.ServiceClient, id string, opts *ConnectorOpts) actionsResult {
+	var result actionsResult
+	connector, err := opts.ToConnectorMap()
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	reqBody := map[string]interface{}{"os-terminate_connection": connector}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return result
+}
+
+func Detach(client *gophercloud.ServiceClient, id string) actionsResult {
+	var result actionsResult
+	empty_val := make(map[string]interface{})
+	reqBody := map[string]interface{}{"os-detach": empty_val}
+	_, result.Err = client.Post(volumeActionsURL(client, id), reqBody, &result.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return result
+}

--- a/openstack/blockstorage/extensions/volumeactions/requests_test.go
+++ b/openstack/blockstorage/extensions/volumeactions/requests_test.go
@@ -1,0 +1,77 @@
+package volumeactions
+
+import (
+	fixtures "github.com/rackspace/gophercloud/openstack/blockstorage/extensions/volumeactions/testing"
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+	"testing"
+)
+
+func TestReserve(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockReserveResponse(t)
+	res := Reserve(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestInitializeConnection(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockInitializeConnectionResponse(t)
+	connector := &ConnectorOpts{
+		IP:        "192.168.0.37",
+		Host:      "devbox",
+		Initiator: "iqn.1993-08.org.debian:01:17a0e6ac38f8",
+		MultiPath: false,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+	res := InitializeConnection(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15", connector)
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestAttach(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockAttachResponse(t)
+	options := &AttachOpts{
+		MountPoint:   "/dev/vdb",
+		Mode:         "rw",
+		InstanceUUID: "4e6b240c-e32a-4e7b-8453-e4ed0f5eb107",
+	}
+	res := Attach(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15", options)
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestUnReserve(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockUnReserveResponse(t)
+	res := UnReserve(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestTermianteConnection(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockTerminateConnectionResponse(t)
+	connector := &ConnectorOpts{
+		IP:        "192.168.0.37",
+		Host:      "devbox",
+		Initiator: "iqn.1993-08.org.debian:01:17a0e6ac38f8",
+		MultiPath: false,
+		Platform:  "x86_64",
+		OSType:    "linux2",
+	}
+	res := TerminateConnection(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15", connector)
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestDetach(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	fixtures.MockUnReserveResponse(t)
+	res := UnReserve(client.ServiceClient(), "58003305-1778-43ce-ac78-a81fe255db15")
+	th.AssertNoErr(t, res.Err)
+}

--- a/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,0 +1,22 @@
+package volumeactions
+
+import (
+	"github.com/rackspace/gophercloud"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// We need a local result type, just declare one here and use the generic
+// gophercloud.Result
+type actionsResult struct {
+	gophercloud.Result
+}
+
+func (r actionsResult) Extract() (map[string]interface{}, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	var res map[string]interface{}
+	err := mapstructure.Decode(r.Body, &res)
+	return res, err
+}

--- a/openstack/blockstorage/extensions/volumeactions/testing/doc.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/doc.go
@@ -1,0 +1,7 @@
+/*
+This is package created is to hold fixtures (which imports testing),
+so that importing volumes package does not inadvertently import testing into production code
+More information here:
+https://github.com/rackspace/gophercloud/issues/473
+*/
+package testing

--- a/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
+++ b/openstack/blockstorage/extensions/volumeactions/testing/fixtures.go
@@ -1,0 +1,200 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	fake "github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func MockAttachResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-attach":
+    {
+        "mountpoint": "/dev/vdb",
+        "mode": "rw",
+        "instance_uuid": "4e6b240c-e32a-4e7b-8453-e4ed0f5eb107"
+    }
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
+func MockReserveResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-reserve": {}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
+func MockUnreserveResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-unreserve": {}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
+func MockInitializeConnectionResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-initialize_connection":
+    {
+        "connector":
+        {
+        "ip":"192.168.0.37",
+        "host":"devbox",
+		"initiator":"iqn.1993-08.org.debian:01:17a0e6ac38f8",
+        "multipath": false,
+        "platform": "x86_64",
+        "os_type": "linux2"
+        }
+    }
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `
+{
+    "connection_info":
+    {
+        "driver_volume_type": "iscsi",
+        "data":
+        {
+            "target_discovered": false,
+            "encrypted": false,
+            "target_iqn": "iqn.2010-10.org.openstack:volume-58003305-1778-43ce-ac78-a81fe255db15",
+            "target_portal": "192.168.0.37:3260",
+            "volume_id": "58003305-1778-43ce-ac78-a81fe255db15",
+            "target_lun": 1,
+            "access_mode": "rw",
+            "auth_username": "fRYNAWbGR7HRYwUhHGa6",
+            "auth_password": "J3CEGp2EEtfAqk4T",
+            "auth_method": "CHAP",
+			"qos_specs": null
+        }
+    }
+}`)
+		})
+}
+
+func MockTerminateConnectionResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+	"os-terminate_connection":
+	{
+		"connector":
+		{
+			"initiator": "iqn.1993-08.org.debian:01:17a0e6ac38f8",
+			"ip": "192.168.0.37",
+			"platform": "x86_64",
+			"host": "devbox",
+			"os_type": "linux2",
+			"multipath": false
+		}
+	}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
+func MockUnReserveResponse(t *testing.T) {
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-unreserve": {}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}
+
+func MockDetachResponse(t *testing.T) {
+	// TOD(jdg): Add optional attach_id, for now it's not interesting because
+	// Cinder doesn't actually provide it; BUT future proposal is to return it
+	// to caller on initialize_connection
+	th.Mux.HandleFunc("/volumes/58003305-1778-43ce-ac78-a81fe255db15/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+			th.TestJSONRequest(t, r, `
+{
+    "os-detach": {}
+}
+          `)
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+
+			fmt.Fprintf(w, `{}`)
+		})
+}

--- a/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -1,0 +1,7 @@
+package volumeactions
+
+import "github.com/rackspace/gophercloud"
+
+func volumeActionsURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id, "action")
+}


### PR DESCRIPTION
Add volumeactions extension to blockstorage
module.  For now just start with basic attach
and detach commands and their associated
helpers.

Note that extensions are currently API version
independent in Cinder and are shared regardless
of configured Cinder API endpoint.

Add the following Cinder calls:
* reserve
* initialize_connection
* attach
* unreserve
* terminate_connection
* detach

For information on Cinder attach/detach workflow see:
http://docs.openstack.org/developer/cinder/devref/attach_detach_conventions.html