### PR TITLE
Fix selection of v2 volumes in openstack blockstorage

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -283,25 +283,12 @@ func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 
 // NewBlockStorageV2 creates a ServiceClient that may be used to access the v2 block storage service.
 func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
-	eo.ApplyDefaults("volume")
+	eo.ApplyDefaults("volumev2")
 	url, err := client.EndpointLocator(eo)
 	if err != nil {
 		return nil, err
 	}
-
-	// Force using v2 API
-	if strings.Contains(url, "/v1") {
-		url = strings.Replace(url, "/v1", "/v2", -1)
-	}
-	if !strings.Contains(url, "/v2") {
-		return nil, fmt.Errorf("Block Storage v2 endpoint not found")
-	}
-
-	return &gophercloud.ServiceClient{
-		ProviderClient: client,
-		Endpoint:       url,
-		ResourceBase:   url,
-	}, nil
+	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url}, nil
 }
 
 // NewCDNV1 creates a ServiceClient that may be used to access the OpenStack v1


### PR DESCRIPTION
After reviewing #489 I think this is a better way of selecting v2 volumes.  It certainly works in my testing.

This was committed originally in da546143

@feiskyer since you wrote the original code do you agree?

I'm unable to find the definitive openstack document which states valid values for the type field in the catalog though!



