### PR TITLE
Fix openstack NewClient to not remove relative paths from IdentityBase

### DIFF
--- a/openstack/client.go
+++ b/openstack/client.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"fmt"
 	"net/url"
-	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/rackspace/gophercloud"
@@ -16,8 +16,6 @@ const (
 	v20 = "v2.0"
 	v30 = "v3.0"
 )
-
-var VERSION_PATTERN = regexp.MustCompile("/v[1-9]{1}[0-9\\.]{0,2}/")
 
 // NewClient prepares an unauthenticated ProviderClient instance.
 // Most users will probably prefer using the AuthenticatedClient function instead.
@@ -34,23 +32,33 @@ func NewClient(endpoint string) (*gophercloud.ProviderClient, error) {
 	// Base is url with path
 	endpoint = gophercloud.NormalizeURL(endpoint)
 	base := gophercloud.NormalizeURL(u.String())
-	var location = VERSION_PATTERN.FindStringIndex(base)
 
-	if location != nil {
-		var version = base[location[0]+1:location[1]-1]
-		switch version {
-		case "v2.0", "v3":
-			// post version suffixes in path are not supported
-			if len(base) > location[1] {
-				return nil, fmt.Errorf("Path suffixes (after version) are not supported.")
+	path := u.Path
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+
+	parts := strings.Split(path[0:len(path)-1], "/")
+	for index,version := range(parts) {
+		if 2 <= len(version) && len(version) <= 4 && strings.HasPrefix(version, "v") {
+			_, err := strconv.ParseFloat(version[1:], 64)
+			if err == nil {
+				// post version suffixes in path are not supported
+				// version must be on the last index
+				if index < len(parts) - 1 {
+					return nil, fmt.Errorf("Path suffixes (after version) are not supported.")
+				}
+				switch version {
+				case "v2.0", "v3":
+					// valid version found, strip from base
+					return &gophercloud.ProviderClient{
+						IdentityBase:     base[0:len(base)-len(version)-1],
+						IdentityEndpoint: endpoint,
+					}, nil
+				default:
+					return nil, fmt.Errorf("Invalid identity endpoint version %v. Supported versions: v2.0, v3", version)
+				}
 			}
-			// valid version found, strip from base
-			return &gophercloud.ProviderClient{
-				IdentityBase:     base[0:location[0]+1],
-				IdentityEndpoint: endpoint,
-			}, nil
-		default:
-			return nil, fmt.Errorf("Invalid identity endpoint version %v. Supported versions: v2.0, v3", version)
 		}
 	}
 

--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -200,4 +200,54 @@ func TestNewClient(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.AssertEquals(t, "https://example.com/foo/bar/v2.0/", client.IdentityEndpoint)
 	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/foo/bar/v3/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/foo/bar/v3/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/v3")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/v3/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/v3/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/v3/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	_, err = NewClient("https://example.com/v2.3/")
+	th.AssertErr(t, err)
+	expected := fmt.Errorf("Invalid identity endpoint version %v. Supported versions: v2.0, v3", "v2.3")
+	th.AssertEquals(t, expected.Error(), err.Error())
+
+	_, err = NewClient("https://example.com/v2.0/foo")
+	th.AssertErr(t, err)
+	expected = fmt.Errorf("Path suffixes (after version) are not supported.")
+	th.AssertEquals(t, expected.Error(), err.Error())
+
+	// Does not match regexp, include to base
+	client, err = NewClient("https://example.com/v2a0/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/v2a0/", client.IdentityBase)
+
+	// Does not match regexp, include to base
+	client, err = NewClient("https://example.com/v3api")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/v3api/", client.IdentityBase)
+
+	// Matches regexp, invalid version v20.
+	_, err = NewClient("https://example.com/v20./")
+	th.AssertErr(t, err)
+	expected = fmt.Errorf("Invalid identity endpoint version %v. Supported versions: v2.0, v3", "v20.")
+	th.AssertEquals(t, expected.Error(), err.Error())
+
+	// domain contains version
+	client, err = NewClient("https://v3.v2.0example.com/v3/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://v3.v2.0example.com/v3/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://v3.v2.0example.com/", client.IdentityBase)
+
 }

--- a/openstack/client_test.go
+++ b/openstack/client_test.go
@@ -159,3 +159,45 @@ func TestAuthenticatedClientV2(t *testing.T) {
 	th.AssertNoErr(t, err)
 	th.CheckEquals(t, "01234567890", client.TokenID)
 }
+
+func TestNewClient(t *testing.T) {
+	client, err := NewClient("https://example.com")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/v2.0")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/v2.0/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/v2.0/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/v2.0/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/foo/bar")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/foo/bar/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/foo/bar/v2.0")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/foo/bar/v2.0/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+
+	client, err = NewClient("https://example.com/foo/bar/v2.0/")
+	th.AssertNoErr(t, err)
+	th.AssertEquals(t, "https://example.com/foo/bar/v2.0/", client.IdentityEndpoint)
+	th.AssertEquals(t, "https://example.com/foo/bar/", client.IdentityBase)
+}

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -224,6 +224,21 @@ func CheckEquals(t *testing.T, expected, actual interface{}) {
 	}
 }
 
+// AssertErr is a convenience function for checking that an error occurred
+func AssertErr(t *testing.T, e error) {
+	if e == nil {
+		logFatal(t, fmt.Sprintf("expected an error but none occurred"))
+	}
+}
+
+// CheckErr is a convenience function for checking that an error occurred,
+// except with a non-fatal error
+func CheckErr(t *testing.T, e error) {
+	if e == nil {
+		logError(t, fmt.Sprintf("expected an error but none occurred"))
+	}
+}
+
 // AssertDeepEquals - like Equals - performs a comparison - but on more complex
 // structures that requires deeper inspection
 func AssertDeepEquals(t *testing.T, expected, actual interface{}) {


### PR DESCRIPTION
gophercloud.provider_client.go struct ProviderClient describes IdentityBase as
follows: "IdentityBase is the base URL used for a particular provider's
identity service - it will be used when issuing authenticatation requests. It
should point to the root resource of the identity service, not a specific
identity version."

Currently gophercloud.openstack.client.go func NewClient strips endpoints with
a non-empty relative path. For example, the IdentityBase returned for endpoint:

  http://example.com/foo

is:

  http://example.com/

when it should be:

  http://example.com/foo/

This change fixes NewClient to correctly handle such cases.

Unit tests are provided in openstack.test_client.go

[1] gophercloud.openstack.client.go

Fixes-Issue: #577