### PR TITLE
[RFR] add admin actions

### DIFF
--- a/openstack/compute/v2/extensions/adminactions/doc.go
+++ b/openstack/compute/v2/extensions/adminactions/doc.go
@@ -1,0 +1,5 @@
+/*
+Package provides access to the "Admin Actions" of the Compute API,
+including migrations, live-migrations, reset-state, etc.
+*/
+package adminactions

--- a/openstack/compute/v2/extensions/adminactions/fixtures.go
+++ b/openstack/compute/v2/extensions/adminactions/fixtures.go
@@ -1,0 +1,77 @@
+// +build fixtures
+
+package adminactions
+
+import (
+	"net/http"
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func mockCreateBackupResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"createBackup": {"name": "Backup 1", "backup_type": "daily", "rotation": 1}}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockInjectNetworkInfoResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"injectNetworkInfo": ""}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockMigrateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"migrate": ""}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+const liveMigrateRequest = `{"os-migrateLive": {"host": "", "disk_over_commit": false, "block_migration": true}}`
+const targetLiveMigrateRequest = `{"os-migrateLive": {"host": "target-compute", "disk_over_commit": false, "block_migration": true}}`
+
+func mockLiveMigrateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, liveMigrateRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockTargetLiveMigrateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, targetLiveMigrateRequest)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockResetNetworkResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"resetNetwork": ""}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func mockResetStateResponse(t *testing.T, id string) {
+	th.Mux.HandleFunc("/servers/"+id+"/action", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{"os-resetState": {"state": "active"}}`)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}

--- a/openstack/compute/v2/extensions/adminactions/requests.go
+++ b/openstack/compute/v2/extensions/adminactions/requests.go
@@ -1,6 +1,10 @@
 package adminactions
 
-import "github.com/rackspace/gophercloud"
+import (
+	"fmt"
+
+	"github.com/rackspace/gophercloud"
+)
 
 func actionURL(client *gophercloud.ServiceClient, id string) string {
 	return client.ServiceURL("servers", id, "action")
@@ -21,12 +25,17 @@ type CreateBackupOpts struct {
 func (opts CreateBackupOpts) ToCreateBackupMap() (map[string]interface{}, error) {
 	backup := make(map[string]interface{})
 
-	if opts.Name != "" {
-		backup["name"] = opts.Name
+	if opts.Name == "" {
+		return nil, fmt.Errorf("CreateBackupOpts.Name cannot be blank.")
 	}
-	if opts.BackupType != "" {
-		backup["backup_type"] = opts.BackupType
+	if opts.BackupType == "" {
+		return nil, fmt.Errorf("CreateBackupOpts.BackupType cannot be blank.")
 	}
+	if opts.Rotation < 0 {
+		return nil, fmt.Errorf("CreateBackupOpts.Rotation must 0 or greater.")
+	}
+	backup["name"] = opts.Name
+	backup["backup_type"] = opts.BackupType
 	backup["rotation"] = opts.Rotation
 
 	return map[string]interface{}{"createBackup": backup}, nil

--- a/openstack/compute/v2/extensions/adminactions/requests.go
+++ b/openstack/compute/v2/extensions/adminactions/requests.go
@@ -1,0 +1,134 @@
+package adminactions
+
+import "github.com/rackspace/gophercloud"
+
+func actionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("servers", id, "action")
+}
+
+type CreateBackupOpts struct {
+	// Name: required, name of the backup.
+	Name string
+
+	// BackupType: required, type of the backup, such as "daily".
+	BackupType string
+
+	// Rotation: the number of backups to retain.
+	Rotation int
+}
+
+// ToBackupCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateBackupOpts) ToCreateBackupMap() (map[string]interface{}, error) {
+	backup := make(map[string]interface{})
+
+	if opts.Name != "" {
+		backup["name"] = opts.Name
+	}
+	if opts.BackupType != "" {
+		backup["backup_type"] = opts.BackupType
+	}
+	backup["rotation"] = opts.Rotation
+
+	return map[string]interface{}{"createBackup": backup}, nil
+}
+
+// ResetNetwork is the admin operation to create a backup of a Compute Server.
+func CreateBackup(client *gophercloud.ServiceClient, id string, opts CreateBackupOpts) gophercloud.ErrResult {
+	var res gophercloud.ErrResult
+
+	req, err := opts.ToCreateBackupMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+
+}
+
+// InjectNetworkInfo is the admin operation which injects network info into a Compute Server.
+func InjectNetworkInfo(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
+	var req struct {
+		InjectNetworkInfo string `json:"injectNetworkInfo"`
+	}
+
+	var res gophercloud.ErrResult
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+}
+
+// Migrate is the admin operation to migrate a Compute Server.
+func Migrate(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
+	var req struct {
+		Migrate string `json:"migrate"`
+	}
+
+	var res gophercloud.ErrResult
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+}
+
+type LiveMigrateOpts struct {
+	// Host: optional, If you omit this parameter, the scheduler chooses a host.
+	Host string
+
+	// BlockMigration:  defaults to false. Set to true to migrate local disks
+	// by using block migration. If the source or destination host uses shared storage
+	// and you set this value to true, the live migration fails.
+	BlockMigration bool
+
+	//DiskOverCommit: defaults to false. Set to true to enable over commit when the
+	// destination host is checked for available disk space.
+	DiskOverCommit bool
+}
+
+// ToServerCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts LiveMigrateOpts) ToLiveMigrateMap() (map[string]interface{}, error) {
+	migration := make(map[string]interface{})
+
+	migration["host"] = opts.Host
+	migration["block_migration"] = opts.BlockMigration
+	migration["disk_over_commit"] = opts.DiskOverCommit
+
+	return map[string]interface{}{"os-migrateLive": migration}, nil
+}
+
+// ResetNetwork is the admin operation to reset the network on a Compute Server.
+func LiveMigrate(client *gophercloud.ServiceClient, id string, opts LiveMigrateOpts) gophercloud.ErrResult {
+	var res gophercloud.ErrResult
+
+	req, err := opts.ToLiveMigrateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+
+}
+
+// ResetNetwork is the admin operation to reset the network on a Compute Server.
+func ResetNetwork(client *gophercloud.ServiceClient, id string) gophercloud.ErrResult {
+	var req struct {
+		ResetNetwork string `json:"resetNetwork"`
+	}
+
+	var res gophercloud.ErrResult
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+}
+
+// ResetState is the admin operation to reset the state of a server.
+func ResetState(client *gophercloud.ServiceClient, id string, state string) gophercloud.ErrResult {
+	var res gophercloud.ErrResult
+	var req struct {
+		ResetState struct {
+			State string `json:"state"`
+		} `json:"os-resetState"`
+	}
+	req.ResetState.State = state
+
+	_, res.Err = client.Post(actionURL(client, id), req, nil, nil)
+	return res
+}

--- a/openstack/compute/v2/extensions/adminactions/requests_test.go
+++ b/openstack/compute/v2/extensions/adminactions/requests_test.go
@@ -1,6 +1,7 @@
 package adminactions
 
 import (
+	"fmt"
 	"testing"
 
 	th "github.com/rackspace/gophercloud/testhelper"
@@ -21,6 +22,53 @@ func TestCreateBackup(t *testing.T) {
 		Rotation:   1,
 	}).ExtractErr()
 	th.AssertNoErr(t, err)
+}
+
+func TestCreateBackupNoName(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateBackupResponse(t, serverID)
+
+	err := CreateBackup(client.ServiceClient(), serverID, CreateBackupOpts{
+		BackupType: "daily",
+		Rotation:   1,
+	}).ExtractErr()
+	if err == nil {
+		fmt.Errorf("CreateBackup without a specified Name should throw an Error.")
+	}
+}
+
+func TestCreateBackupNegativeRotation(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateBackupResponse(t, serverID)
+
+	err := CreateBackup(client.ServiceClient(), serverID, CreateBackupOpts{
+		Name:       "Backup 1",
+		BackupType: "daily",
+		Rotation:   -1,
+	}).ExtractErr()
+	if err == nil {
+		fmt.Errorf("CreateBackup without a negative Rotation should throw an Error.")
+	}
+}
+
+func TestCreateBackupNoType(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateBackupResponse(t, serverID)
+
+	err := CreateBackup(client.ServiceClient(), serverID, CreateBackupOpts{
+		Name: "Backup 1",
+
+		Rotation: 1,
+	}).ExtractErr()
+	if err == nil {
+		fmt.Errorf("CreateBackup without a specified BackupType should throw an Error.")
+	}
 }
 
 func TestInjectNetworkInfo(t *testing.T) {

--- a/openstack/compute/v2/extensions/adminactions/requests_test.go
+++ b/openstack/compute/v2/extensions/adminactions/requests_test.go
@@ -1,0 +1,89 @@
+package adminactions
+
+import (
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+const serverID = "adef1234"
+
+func TestCreateBackup(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockCreateBackupResponse(t, serverID)
+
+	err := CreateBackup(client.ServiceClient(), serverID, CreateBackupOpts{
+		Name:       "Backup 1",
+		BackupType: "daily",
+		Rotation:   1,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestInjectNetworkInfo(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockInjectNetworkInfoResponse(t, serverID)
+
+	err := InjectNetworkInfo(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestMigrate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockMigrateResponse(t, serverID)
+
+	err := Migrate(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestLiveMigrate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockLiveMigrateResponse(t, serverID)
+
+	err := LiveMigrate(client.ServiceClient(), serverID, LiveMigrateOpts{
+		BlockMigration: true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestTargetLiveMigrate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockTargetLiveMigrateResponse(t, serverID)
+
+	err := LiveMigrate(client.ServiceClient(), serverID, LiveMigrateOpts{
+		Host:           "target-compute",
+		BlockMigration: true,
+	}).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestResetNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockResetNetworkResponse(t, serverID)
+
+	err := ResetNetwork(client.ServiceClient(), serverID).ExtractErr()
+	th.AssertNoErr(t, err)
+}
+
+func TestResetState(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	mockResetStateResponse(t, serverID)
+
+	err := ResetState(client.ServiceClient(), serverID, "active").ExtractErr()
+	th.AssertNoErr(t, err)
+}


### PR DESCRIPTION
This PR adds all available admin actions to the "adminactions" extension.

API Docs for these functions are available here:
http://developer.openstack.org/api-ref-compute-v2.1.html#os-admin-actions-v2.1

The actions added are:
- createBackup
- injectNetworkInfo
- Migrate
- LiveMigrate
- ResetNetwork
- ResetState
