### PR TITLE
Fix typos in "List Objects" doc

### DIFF
--- a/docs/object-storage/index.md
+++ b/docs/object-storage/index.md
@@ -204,12 +204,12 @@ err := pager.EachPage(func(page pagination.Page) (bool, error) {
 
 	// Get a slice of objects.Object structs
 	objectList, err := objects.ExtractInfo(page)
-	for _, n := range objectNames {
+	for _, o := range objectList {
 		// ...
 	}
 
 	// Get a slice of strings, i.e. object names
-	objectNames, err := containers.ExtractNames(page)
+	objectNames, err := objects.ExtractNames(page)
 	for _, n := range objectNames {
 		// ...
 	}


### PR DESCRIPTION
[Fix #568]
- 207: using previously declared "ObjectList" rather than "ObjectNames" which is for 212 instead.
- 212: using "objects.ExtractNames" rather than "containers.ExtractNames"