### PR TITLE
fixing build constraints for lbaas_v2 fixtures

### DIFF
--- a/openstack/networking/v2/extensions/lbaas_v2/listeners/fixtures.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/listeners/fixtures.go
@@ -1,4 +1,5 @@
 // +build fixtures
+
 package listeners
 
 import (

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/fixtures.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/fixtures.go
@@ -1,4 +1,5 @@
 // +build fixtures
+
 package loadbalancers
 
 import (

--- a/openstack/networking/v2/extensions/lbaas_v2/monitors/fixtures.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/monitors/fixtures.go
@@ -1,4 +1,5 @@
 // +build fixtures
+
 package monitors
 
 import (

--- a/openstack/networking/v2/extensions/lbaas_v2/pools/fixtures.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/pools/fixtures.go
@@ -1,4 +1,5 @@
 // +build fixtures
+
 package pools
 
 import (


### PR DESCRIPTION
Build constraints are missing a line after the build constraint
as required by https://golang.org/pkg/go/build/, and the fixtures
are being pulled in by standard builds, causing test code to be
included in the final binary.