### PR TITLE
Support cinder volume create multiattach option

### DIFF
--- a/openstack/blockstorage/v1/volumes/requests.go
+++ b/openstack/blockstorage/v1/volumes/requests.go
@@ -31,6 +31,8 @@ type CreateOpts struct {
 	SnapshotID, SourceVolID, ImageID string
 	// OPTIONAL
 	VolumeType string
+	// OPTIONAL
+	Multiattach bool
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
@@ -66,6 +68,9 @@ func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
 	}
 	if opts.VolumeType != "" {
 		v["volume_type"] = opts.VolumeType
+	}
+	if opts.Multiattach {
+		v["multiattach"] = true
 	}
 
 	return map[string]interface{}{"volume": v}, nil

--- a/openstack/blockstorage/v1/volumes/results.go
+++ b/openstack/blockstorage/v1/volumes/results.go
@@ -42,6 +42,9 @@ type Volume struct {
 	// Arbitrary key-value pairs defined by the user.
 	Metadata map[string]string `mapstructure:"metadata"`
 
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `mapstructure:"multiattach"`
+
 	// Unique identifier for the volume.
 	ID string `mapstructure:"id"`
 

--- a/openstack/blockstorage/v2/volumes/requests.go
+++ b/openstack/blockstorage/v2/volumes/requests.go
@@ -40,6 +40,8 @@ type CreateOpts struct {
 	ImageID string
 	// The associated volume type [OPTIONAL]
 	VolumeType string
+	// OPTIONAL
+	Multiattach bool
 }
 
 // ToVolumeCreateMap assembles a request body based on the contents of a
@@ -81,6 +83,9 @@ func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
 	}
 	if opts.VolumeType != "" {
 		v["volume_type"] = opts.VolumeType
+	}
+	if opts.Multiattach {
+		v["multiattach"] = true
 	}
 
 	return map[string]interface{}{"volume": v}, nil


### PR DESCRIPTION
both v1 and v2 cinder volume create api support multiattach option. Provide them so that callers can use it when necessary.