### PR TITLE
fix cinder detach parameter

### DIFF
--- a/openstack/blockstorage/v2/extensions/volumeactions/fixtures.go
+++ b/openstack/blockstorage/v2/extensions/volumeactions/fixtures.go
@@ -43,7 +43,7 @@ func MockDetachResponse(t *testing.T) {
 			th.TestHeader(t, r, "Accept", "application/json")
 			th.TestJSONRequest(t, r, `
 {
-    "os-detach": {}
+    "os-force_detach": {}
 }
           `)
 

--- a/openstack/blockstorage/v2/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/v2/extensions/volumeactions/requests.go
@@ -74,7 +74,7 @@ func Detach(client *gophercloud.ServiceClient, id string) DetachResult {
 	var res DetachResult
 
 	v := make(map[string]interface{})
-	reqBody := map[string]interface{}{"os-detach": v}
+	reqBody := map[string]interface{}{"os-force_detach": v}
 
 	_, res.Err = client.Post(detachURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{202},


### PR DESCRIPTION
It is "os-froce_detach" per http://developer.openstack.org/api-ref-blockstorage-v2.html

Signed-off-by: Peng Tao <bergwolf@gmail.com>