### PR TITLE
[rfr] Only pass volume_size if it is greater than zero

### DIFF
--- a/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -79,7 +79,9 @@ func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
 		blockDevice[i]["source_type"] = bd.SourceType
 		blockDevice[i]["boot_index"] = strconv.Itoa(bd.BootIndex)
 		blockDevice[i]["delete_on_termination"] = strconv.FormatBool(bd.DeleteOnTermination)
-		blockDevice[i]["volume_size"] = strconv.Itoa(bd.VolumeSize)
+		if bd.VolumeSize > 0 {
+			blockDevice[i]["volume_size"] = strconv.Itoa(bd.VolumeSize)
+		}
 		if bd.UUID != "" {
 			blockDevice[i]["uuid"] = bd.UUID
 		}

--- a/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
+++ b/openstack/compute/v2/extensions/bootfromvolume/requests_test.go
@@ -102,8 +102,7 @@ func TestCreateMultiEphemeralOpts(t *testing.T) {
             "delete_on_termination": "true",
             "destination_type":"local",
             "source_type":"image",
-            "uuid":"123456",
-            "volume_size": "0"
+            "uuid":"123456"
           },
           {
             "boot_index": "-1",


### PR DESCRIPTION
A recent change in Nova now enforces volume_size to be greater than
zero. Since volume_size is an optional parameter, it should now only
be sent when it has a positive non-zero value.