### PR TITLE
[rfr] Making SubnetID optional during pool and vip creation

### DIFF
--- a/openstack/networking/v2/extensions/lbaas/pools/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/pools/requests.go
@@ -86,7 +86,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		Name     string `json:"name"`
 		TenantID string `json:"tenant_id,omitempty"`
 		Protocol string `json:"protocol"`
-		SubnetID string `json:"subnet_id"`
+		SubnetID string `json:"subnet_id,omitempty"`
 		LBMethod string `json:"lb_method"`
 		Provider string `json:"provider,omitempty"`
 	}

--- a/openstack/networking/v2/extensions/lbaas/vips/requests.go
+++ b/openstack/networking/v2/extensions/lbaas/vips/requests.go
@@ -126,10 +126,6 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 		res.Err = errNameRequired
 		return res
 	}
-	if opts.SubnetID == "" {
-		res.Err = errSubnetIDRequried
-		return res
-	}
 	if opts.Protocol == "" {
 		res.Err = errProtocolRequired
 		return res
@@ -145,7 +141,7 @@ func Create(c *gophercloud.ServiceClient, opts CreateOpts) CreateResult {
 
 	type vip struct {
 		Name         string              `json:"name"`
-		SubnetID     string              `json:"subnet_id"`
+		SubnetID     string              `json:"subnet_id,omitempty"`
 		Protocol     string              `json:"protocol"`
 		ProtocolPort int                 `json:"protocol_port"`
 		PoolID       string              `json:"pool_id"`

--- a/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -131,8 +131,6 @@ func (opts CreateOpts) ToLoadbalancerCreateMap() (map[string]interface{}, error)
 
 	if opts.VipSubnetID != "" {
 		l["vip_subnet_id"] = opts.VipSubnetID
-	} else {
-		return nil, errVipSubnetIDRequried
 	}
 	if opts.AdminStateUp != nil {
 		l["admin_state_up"] = &opts.AdminStateUp


### PR DESCRIPTION
At eBay, we have made changes to openstack to not have SubnetID mandatory during loadbalancer pool and vip creation. The LbaaS scheduler will find the right LB and the right subnet to create a vip and pool. And hence this can be optional.

This patch is needed to integrate Kubernetes with our internal private cloud LBaaS

cc @ashw7n @khgandhi
