### PR TITLE
detaching volume by attachment_id

### DIFF
--- a/openstack/blockstorage/v2/extensions/volumeactions/fixtures.go
+++ b/openstack/blockstorage/v2/extensions/volumeactions/fixtures.go
@@ -43,7 +43,10 @@ func MockDetachResponse(t *testing.T) {
 			th.TestHeader(t, r, "Accept", "application/json")
 			th.TestJSONRequest(t, r, `
 {
-    "os-detach": {}
+    "os-detach":
+    {
+        "attachment_id": "d8483b65-515b-4dae-b811-3ffaca3cc6e7"
+    }
 }
           `)
 

--- a/openstack/blockstorage/v2/extensions/volumeactions/requests.go
+++ b/openstack/blockstorage/v2/extensions/volumeactions/requests.go
@@ -70,10 +70,15 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 }
 
 // Attach will detach a volume based on volume id.
-func Detach(client *gophercloud.ServiceClient, id string) DetachResult {
+func Detach(client *gophercloud.ServiceClient, id string, attachmentId string) DetachResult {
 	var res DetachResult
 
 	v := make(map[string]interface{})
+
+	if attachmentId != "" {
+		v["attachment_id"] = attachmentId
+	}
+
 	reqBody := map[string]interface{}{"os-detach": v}
 
 	_, res.Err = client.Post(detachURL(client, id), reqBody, nil, &gophercloud.RequestOpts{

--- a/openstack/blockstorage/v2/extensions/volumeactions/requests_test.go
+++ b/openstack/blockstorage/v2/extensions/volumeactions/requests_test.go
@@ -28,7 +28,7 @@ func TestDetach(t *testing.T) {
 
 	MockDetachResponse(t)
 
-	err := Detach(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c").ExtractErr()
+	err := Detach(client.ServiceClient(), "cd281d77-8217-4830-be95-9528227c105c", "d8483b65-515b-4dae-b811-3ffaca3cc6e7").ExtractErr()
 	th.AssertNoErr(t, err)
 }
 

--- a/openstack/blockstorage/v2/volumes/results.go
+++ b/openstack/blockstorage/v2/volumes/results.go
@@ -71,6 +71,9 @@ type Volume struct {
 
 	// UserID is the id of the user who created the volume.
 	UserID string `mapstructure:"user_id"`
+
+	// Attachment identifier for detaching a volume from a storage
+	AttachmentID string `mapstructure:"attachment_id"`
 }
 
 // CreateResult contains the response body and error from a Create request.


### PR DESCRIPTION
This is a patch for detaching volume by attachment_id,
when using in attaching a same volume to multiple hosts.
This patch, Of course, support both 1:1 and 1:N attachment.

Currently, detaching logic in gophercloud can only support on 1:1(volume:host) attachment.
But many users want to be able to attach the same volume to multiple hosts.
(for example : clustered application(A:P))

BP : https://specs.openstack.org/openstack/cinder-specs/specs/kilo/multi-attach-volume.html

Signed-off-by: Jangseon Ryu <jangseon.ryu@navercorp.com>