### PR TITLE
Update godep directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go get github.com/rackspace/gophercloud
 godep save ./...
 ```
 
-This will install all the source files you need into a `Godeps/_workspace` directory, which is
+This will install all the source files you need into a `vendor/` directory (or `Godeps/_workspace` when using older versions of Go), which is
 referenceable from your own source files when you use the `godep go` command.
 
 ## Getting started


### PR DESCRIPTION
Using `godep save ./...`  will save a list of dependencies to the file `Godeps/Godeps.json` and copy their source code into `vendor/` (or `Godeps/_workspace/` when using older versions of Go).  So I changed the docs, thanks!