### PR TITLE
Add V2 Snapshots object for Cinder

### DIFF
--- a/openstack/blockstorage/v2/snapshots/doc.go
+++ b/openstack/blockstorage/v2/snapshots/doc.go
@@ -1,0 +1,5 @@
+// Package snapshots provides information and interaction with snapshots in the
+// OpenStack Block Storage service. A snapshot is a point in time copy of a
+// volume.  Snapshots can be used to take a point in time copy of a volume, and
+// then used to create a new volume in the future.
+package snapshots

--- a/openstack/blockstorage/v2/snapshots/fixtures.go
+++ b/openstack/blockstorage/v2/snapshots/fixtures.go
@@ -1,0 +1,116 @@
+package snapshots
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	th "github.com/rackspace/gophercloud/testhelper"
+	fake "github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func MockCreateResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestJSONRequest(t, r, `
+{
+    "snapshot": {
+        "name": "snap-001",
+        "volume_id": "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+        "description": "test-snapshot",
+		"force": false
+    }
+}
+      `)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+
+		fmt.Fprintf(w, `
+{
+    "snapshot": {
+        "name": "snap-001",
+        "volume_id": "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+        "desription": "test-snapshot",
+		"size": 1,
+		"id": "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af"
+    }
+}
+	`)
+	})
+}
+
+func MockGetResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/4ee8a3f6-d1c8-4541-ad09-06b7e84a68af", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `
+{
+  "snapshot":
+    {"status": "available",
+     "description": "test-snapshot",
+     "updated_at": "2017-05-31T14:18:36.000000",
+     "volume_id": "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+     "id": "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af",
+     "size": 1,
+     "name": "snap-001",
+     "created_at": "2017-05-31T14:18:35.000000",
+     "metadata": {}
+    }
+}
+      `)
+	})
+}
+
+func MockDeleteResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/4ee8a3f6-d1c8-4541-ad09-06b7e84a68af", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func MockListResponse(t *testing.T) {
+	th.Mux.HandleFunc("/snapshots/detail", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+  {
+  "snapshots": [
+    {
+      "status": "available",
+      "description": null,
+      "updated_at": "2017-05-31T14:18:36.000000",
+      "volume_id": "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+      "id": "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af",
+      "size": 1,
+      "name": null,
+      "created_at": "2017-05-31T14:18:35.000000",
+      "metadata": {"foo": "bar"}
+    },
+    {
+      "status": "available",
+      "description": "this is only a test snapshot",
+      "updated_at": "2017-05-31T14:10:13.000000",
+      "volume_id": "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+      "id": "c970ff21-3c2b-4a4c-b6a0-731808a81776",
+      "size": 1,
+      "name": "test-snap",
+      "created_at": "2017-05-31T14:10:12.000000",
+      "metadata": {}
+      }
+  ]
+  }
+  `)
+	})
+}

--- a/openstack/blockstorage/v2/snapshots/requests.go
+++ b/openstack/blockstorage/v2/snapshots/requests.go
@@ -1,0 +1,217 @@
+package snapshots
+
+import (
+	"fmt"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSnapshotCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Snapshot. This object is passed to
+// the Snapshots.Create function. For more information about these parameters,
+// see the Snapshot object.
+type CreateOpts struct {
+	// The snapshot description [OPTIONAL]
+	Description string
+
+	// One or more metadata key and value pairs to associate with the snapshot [OPTIONAL]
+	Metadata map[string]string
+
+	// The snapshot name [OPTIONAL]
+	Name string
+
+	// the ID of the source volume  to snapshot
+	VolumeID string
+
+	//Force creation even if volume is attached
+	Force bool
+}
+
+// ToSnapshotCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToSnapshotCreateMap() (map[string]interface{}, error) {
+	s := make(map[string]interface{})
+
+	if opts.VolumeID == "" {
+		return nil, fmt.Errorf("Required CreateOpts field 'VolumeID' not set.")
+	}
+	s["volume_id"] = opts.VolumeID
+
+	if opts.Description != "" {
+		s["description"] = opts.Description
+	}
+	if opts.Metadata != nil {
+		s["metadata"] = opts.Metadata
+	}
+	if opts.Name != "" {
+		s["name"] = opts.Name
+	}
+
+	s["force"] = opts.Force
+
+	return map[string]interface{}{"snapshot": s}, nil
+}
+
+// Create will create a new Snapshot based on the values in CreateOpts. To extract
+// the Snapshot object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) CreateResult {
+	var res CreateResult
+
+	reqBody, err := opts.ToSnapshotCreateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	_, res.Err = client.Post(createURL(client), reqBody, &res.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return res
+}
+
+// Delete will delete the existing Snapshot with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) DeleteResult {
+	var res DeleteResult
+	_, res.Err = client.Delete(deleteURL(client, id), nil)
+	return res
+}
+
+// Get retrieves the Snapshot with the provided ID. To extract the Snapshot object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) GetResult {
+	var res GetResult
+	_, res.Err = client.Get(getURL(client, id), &res.Body, nil)
+	return res
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToSnapshotListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Snapshots. It is passed to the Snapshots.List
+// function.
+type ListOpts struct {
+	// admin-only option. Set it to true to see all tenant snapshots.
+	AllTenants bool `q:"all_tenants"`
+	// List only snapshots that contain Metadata.
+	Metadata map[string]string `q:"metadata"`
+	// List only snapshots that have Name as the display name.
+	Name string `q:"name"`
+	// List only snapshots that have a status of Status.
+	Status string `q:"status"`
+}
+
+// ToSnapshotListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSnapshotListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns Snapshots optionally limited by the conditions provided in ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToSnapshotListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	createPage := func(r pagination.PageResult) pagination.Page {
+		return ListResult{pagination.SinglePageBase(r)}
+	}
+
+	return pagination.NewPager(client, url, createPage)
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSnapshotUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Snapshot. This object is passed
+// to the Snapshots.Update function. For more information about the parameters, see
+// the Snapshot object.
+type UpdateOpts struct {
+	// OPTIONAL
+	Name string
+	// OPTIONAL
+	Description string
+}
+
+// ToSnapshotUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToSnapshotUpdateMap() (map[string]interface{}, error) {
+	s := make(map[string]interface{})
+
+	if opts.Description != "" {
+		s["description"] = opts.Description
+	}
+	if opts.Name != "" {
+		s["name"] = opts.Name
+	}
+	return map[string]interface{}{"snapshot": s}, nil
+}
+
+// Update will update the Snapshot with provided information. To extract the updated
+// Snapshot from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) UpdateResult {
+	var res UpdateResult
+
+	reqBody, err := opts.ToSnapshotUpdateMap()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	_, res.Err = client.Put(updateURL(client, id), reqBody, &res.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return res
+}
+
+// IDFromName is a convienience function that returns a server's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	snapshotCount := 0
+	snapshotID := ""
+	if name == "" {
+		return "", fmt.Errorf("A snapshot name must be provided.")
+	}
+	pager := List(client, nil)
+	pager.EachPage(func(page pagination.Page) (bool, error) {
+		snapshotList, err := ExtractSnapshots(page)
+		if err != nil {
+			return false, err
+		}
+
+		for _, s := range snapshotList {
+			if s.Name == name {
+				snapshotCount++
+				snapshotID = s.ID
+			}
+		}
+		return true, nil
+	})
+
+	switch snapshotCount {
+	case 0:
+		return "", fmt.Errorf("Unable to find snapshot: %s", name)
+	case 1:
+		return snapshotID, nil
+	default:
+		return "", fmt.Errorf("Found %d snapshots matching %s", snapshotCount, name)
+	}
+}

--- a/openstack/blockstorage/v2/snapshots/requests_test.go
+++ b/openstack/blockstorage/v2/snapshots/requests_test.go
@@ -1,0 +1,140 @@
+package snapshots
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud/pagination"
+	th "github.com/rackspace/gophercloud/testhelper"
+	"github.com/rackspace/gophercloud/testhelper/client"
+)
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockCreateResponse(t)
+
+	options := &CreateOpts{VolumeID: "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+		Name:        "snap-001",
+		Description: "test-snapshot",
+		Force:       false}
+	n, err := Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, n.Size, 1)
+	th.AssertEquals(t, n.ID, "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af")
+}
+
+func TestGet(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockGetResponse(t)
+
+	s, err := Get(client.ServiceClient(), "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af").Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, s.Name, "snap-001")
+	th.AssertEquals(t, s.ID, "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockDeleteResponse(t)
+
+	res := Delete(client.ServiceClient(), "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af")
+	th.AssertNoErr(t, res.Err)
+}
+
+func TestList(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	count := 0
+
+	List(client.ServiceClient(), &ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		count++
+		actual, err := ExtractSnapshots(page)
+		if err != nil {
+			t.Errorf("Failed to extract snapshots: %v", err)
+			return false, err
+		}
+
+		expected := []Snapshot{
+			{
+				ID:          "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af",
+				Name:        "",
+				CreatedAt:   "2017-05-31T14:18:35.000000",
+				UpdatedAt:   "2017-05-31T14:18:36.000000",
+				Description: "",
+				Metadata:    map[string]string{"foo": "bar"},
+				Size:        1,
+				SourceVolID: "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+				Status:      "available",
+			},
+			{
+				ID:          "c970ff21-3c2b-4a4c-b6a0-731808a81776",
+				Name:        "test-snap",
+				CreatedAt:   "2017-05-31T14:10:12.000000",
+				UpdatedAt:   "2017-05-31T14:10:13.000000",
+				Description: "this is only a test snapshot",
+				Metadata:    map[string]string{},
+				Size:        1,
+				SourceVolID: "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+				Status:      "available",
+			},
+		}
+
+		th.CheckDeepEquals(t, expected, actual)
+
+		return true, nil
+	})
+
+	if count != 1 {
+		t.Errorf("Expected 1 page, got %d", count)
+	}
+}
+
+func TestListAll(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	MockListResponse(t)
+
+	allPages, err := List(client.ServiceClient(), &ListOpts{}).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := ExtractSnapshots(allPages)
+	th.AssertNoErr(t, err)
+
+	expected := []Snapshot{
+		{
+			ID:          "4ee8a3f6-d1c8-4541-ad09-06b7e84a68af",
+			Name:        "",
+			CreatedAt:   "2017-05-31T14:18:35.000000",
+			UpdatedAt:   "2017-05-31T14:18:36.000000",
+			Description: "",
+			Size:        1,
+			SourceVolID: "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+			Status:      "available",
+			Metadata:    map[string]string{"foo": "bar"},
+		},
+		{
+			ID:          "c970ff21-3c2b-4a4c-b6a0-731808a81776",
+			Name:        "test-snap",
+			CreatedAt:   "2017-05-31T14:10:12.000000",
+			UpdatedAt:   "2017-05-31T14:10:13.000000",
+			Description: "this is only a test snapshot",
+			Size:        1,
+			SourceVolID: "32d8295e-17ef-4ea6-9179-eb71f6827f20",
+			Status:      "available",
+			Metadata:    map[string]string{},
+		},
+	}
+
+	th.CheckDeepEquals(t, expected, actual)
+
+}

--- a/openstack/blockstorage/v2/snapshots/results.go
+++ b/openstack/blockstorage/v2/snapshots/results.go
@@ -1,0 +1,102 @@
+package snapshots
+
+import (
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/pagination"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// Snapshot contains all the information associated with an OpenStack Snapshot.
+type Snapshot struct {
+	// The date when this snapshot was created.
+	CreatedAt string `mapstructure:"created_at"`
+
+	// The date when this snapshot was last updated.
+	UpdatedAt string `mapstructure:"updated_at"`
+
+	// Human-readable description for the snapshot.
+	Description string `mapstructure:"description"`
+
+	// Human-readable display name for the snapshot.
+	Name string `mapstructure:"name"`
+
+	// The ID of the snapshots parent snapshot
+	SourceVolID string `mapstructure:"volume_id"`
+
+	// Current status of the snapshot.
+	Status string `mapstructure:"status"`
+
+	// Arbitrary key-value pairs defined by the user.
+	Metadata map[string]string `mapstructure:"metadata"`
+
+	// Unique identifier for the snapshot.
+	ID string `mapstructure:"id"`
+
+	// Size of the snapshot in GB.
+	Size int `mapstructure:"size"`
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ListResult is a pagination.pager that is returned from a call to the List function.
+type ListResult struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Snapshots.
+func (r ListResult) IsEmpty() (bool, error) {
+	snapshots, err := ExtractSnapshots(r)
+	if err != nil {
+		return true, err
+	}
+	return len(snapshots) == 0, nil
+}
+
+// ExtractSnapshots extracts and returns Snapshots. It is used while iterating
+// over a snapshots.List call.
+func ExtractSnapshots(page pagination.Page) ([]Snapshot, error) {
+	var response struct {
+		Snapshots []Snapshot `json:"snapshots"`
+	}
+
+	err := mapstructure.Decode(page.(ListResult).Body, &response)
+	return response.Snapshots, err
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Snapshot object out of the commonResult object.
+func (r commonResult) Extract() (*Snapshot, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	var res struct {
+		Snapshot *Snapshot `json:"snapshots"`
+	}
+
+	err := mapstructure.Decode(r.Body, &res)
+
+	return res.Snapshot, err
+}

--- a/openstack/blockstorage/v2/snapshots/urls.go
+++ b/openstack/blockstorage/v2/snapshots/urls.go
@@ -1,0 +1,23 @@
+package snapshots
+
+import "github.com/rackspace/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("snapshots", "detail")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("snapshots", id)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}

--- a/openstack/blockstorage/v2/snapshots/urls_test.go
+++ b/openstack/blockstorage/v2/snapshots/urls_test.go
@@ -1,0 +1,44 @@
+package snapshots
+
+import (
+	"testing"
+
+	"github.com/rackspace/gophercloud"
+	th "github.com/rackspace/gophercloud/testhelper"
+)
+
+const endpoint = "http://localhost:57909"
+
+func endpointClient() *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{Endpoint: endpoint}
+}
+
+func TestCreateURL(t *testing.T) {
+	actual := createURL(endpointClient())
+	expected := endpoint + "snapshots"
+	th.AssertEquals(t, expected, actual)
+}
+
+func TestListURL(t *testing.T) {
+	actual := listURL(endpointClient())
+	expected := endpoint + "snapshots/detail"
+	th.AssertEquals(t, expected, actual)
+}
+
+func TestDeleteURL(t *testing.T) {
+	actual := deleteURL(endpointClient(), "foo")
+	expected := endpoint + "snapshots/foo"
+	th.AssertEquals(t, expected, actual)
+}
+
+func TestGetURL(t *testing.T) {
+	actual := getURL(endpointClient(), "foo")
+	expected := endpoint + "snapshots/foo"
+	th.AssertEquals(t, expected, actual)
+}
+
+func TestUpdateURL(t *testing.T) {
+	actual := updateURL(endpointClient(), "foo")
+	expected := endpoint + "snapshots/foo"
+	th.AssertEquals(t, expected, actual)
+}

--- a/openstack/blockstorage/v2/snapshots/util.go
+++ b/openstack/blockstorage/v2/snapshots/util.go
@@ -1,0 +1,22 @@
+package snapshots
+
+import (
+	"github.com/rackspace/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}


### PR DESCRIPTION
This adds support for Cinder Snapshot objects using the
OpenStack-Cinder V2 API.

Provides:
  * Create
  * Delete
  * Get
  * List
  * IDFromName