### PR TITLE
Fixes problems with userdata on rackspace

### DIFF
--- a/rackspace/compute/v2/servers/requests.go
+++ b/rackspace/compute/v2/servers/requests.go
@@ -76,6 +76,11 @@ type CreateOpts struct {
 // ToServerCreateMap constructs a request body using all of the OpenStack extensions that are
 // active on Rackspace.
 func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
+
+    if len(opts.UserData) != 0 {
+        opts.ConfigDrive = true
+    }
+
 	base := os.CreateOpts{
 		Name:             opts.Name,
 		ImageRef:         opts.ImageRef,


### PR DESCRIPTION
When creating a server in the Rackspace public cloud the 'UserData'
option does not do anything unless the 'ConfigDrive' option is set to
'true'. This commit fixes that problem by checking if the UserData
option is non-empty and sets 'ConfigDrive' to 'true' if it is.